### PR TITLE
Intercept with original response from target

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ app.use('/proxy', proxy('www.google.com', {
 
 
 
-You can also intercept the response get by proxy before send it back to the client, or change the request options before it get sent to target:
+You can also intercept the response before sending it back to the client, or change the request options before it is sent to the target:
 
 ```js
 app.use('/proxy', proxy('www.google.com', {
   forwardPath: function(req, res) {
     return require('url').parse(req.url).path;
   },
-  intercept: function(data, req, res, callback) {
+  intercept: function(rsp, data, req, res, callback) {
+       // rsp - original response from the target
        data = JSON.parse(data.toString('utf8'));
        callback(null, JSON.stringify(data));
   },
@@ -61,7 +62,11 @@ app.use('/proxy', proxy('www.google.com', {
 
 ```
 
+## Release Notes
 
+| Release | Notes |
+| --- | --- |
+| 0.4.0 | Signature of `intercept` callback changed from `function(data, req, res, callback)` to `function(rsp, data, req, res, callback)` where `rsp` is the original response from the target |
 
 ## Licence
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function proxy(host, options) {
 
 
   /** 
-   * intercept(data, res, req, function(err, json));
+   * intercept(targetResponse, data, res, req, function(err, json));
    */
   var intercept = options.intercept;
   var decorateRequest = options.decorateRequest;
@@ -93,7 +93,7 @@ module.exports = function proxy(host, options) {
           var rspData = Buffer.concat(chunks, totalLength);
 
           if (intercept) {
-            intercept(rspData, req, res, function(err, rspd, sent) {
+            intercept(rsp, rspData, req, res, function(err, rspd, sent) {
               if (err) {
                 return next(err);
               }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-http-proxy",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "http proxy middleware for express",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -49,7 +49,7 @@ describe('http-proxy', function() {
     it('intercept', function(done) {
       var app = express();
       app.use(proxy('httpbin.org', {
-        intercept: function(data, req, res, cb) {
+        intercept: function(rsp, data, req, res, cb) {
           data = JSON.parse(data.toString('utf8'));
           data.intercepted = true;
           cb(null, JSON.stringify(data));
@@ -65,10 +65,25 @@ describe('http-proxy', function() {
         });
     });
 
+    it('test intercept original response', function(done) {
+      var app = express();
+      app.use(proxy('httpbin.org', {
+        intercept: function(rsp, data, req, res, cb) {
+          assert(rsp.connection);
+          assert(rsp.socket);
+          assert(rsp.headers);
+          assert(rsp.headers['content-type']);
+          done();
+        }
+      }));
+
+      request(app).get('/').end();
+    });
+
     it('test intercept on html response',function(done) {
       var app = express();
       app.use(proxy('httpbin.org', {
-        intercept: function(data, req, res, cb) {
+        intercept: function(rsp, data, req, res, cb) {
           data = data.toString().replace('Oh','<strong>Hey</strong>');
           assert(data !== "");
           cb(null, data);
@@ -87,7 +102,7 @@ describe('http-proxy', function() {
     it('test github api', function(done) {
       var app = express();
       app.use(proxy('https://api.github.com',  {
-        intercept: function(data, req, res, cb) {
+        intercept: function(rsp, data, req, res, cb) {
           var Iconv = require('iconv').Iconv;
           var iconv = new Iconv('UTF-8', 'utf8');
           cb(null, data);


### PR DESCRIPTION
Need this to access headers on the original response. This expands on #12 by fixing and expanding unit tests and updating the readme. Version bump to `0.4.0` since #12 introduced a backwards incompatible signature change on the intercept callback.