### PR TITLE
Added request params to decorate request

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ module.exports = function proxy(host, options) {
         headers: hds,
         method: req.method,
         path: path,
-        bodyContent: bodyContent
+        bodyContent: bodyContent,
+        params: req.params
       };
 
 
@@ -78,6 +79,7 @@ module.exports = function proxy(host, options) {
 
       bodyContent = reqOpt.bodyContent;
       delete reqOpt.bodyContent;
+      delete reqOpt.params;
 
       if (typeof bodyContent == 'string')
         reqOpt.headers['content-length'] = Buffer.byteLength(bodyContent);


### PR DESCRIPTION
Hi! 

I think is useful to have other request params when handling the request in decorateRequest function. In my specific case, I need the params of the url. Even may be good to pass the full req object (and delete it later) to have all the info available. ¿What do you think?

Many thanks for the project! 

BR 