### PR TITLE
Allow communication between callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,12 +70,17 @@ module.exports = function proxy(host, options) {
         method: req.method,
         path: path,
         bodyContent: bodyContent,
-        originalUrl: req.originalUrl
+        originalUrl: req.originalUrl,
+        calleeState: null // Initialise to null to indicate that data can be placed here
       };
 
 
       if (decorateRequest)
         reqOpt = decorateRequest(reqOpt) || reqOpt;
+
+      // Copy the state parameter onto the request so the implementer of the
+      // decorateRequest and intercept callbacks can retain state between them
+      req.calleeState = reqOpt.calleeState;
 
       bodyContent = reqOpt.bodyContent;
       delete reqOpt.bodyContent;

--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ module.exports = function proxy(host, options) {
         headers: hds,
         method: req.method,
         path: path,
-        bodyContent: bodyContent
+        bodyContent: bodyContent,
+        originalUrl: req.originalUrl
       };
 
 


### PR DESCRIPTION
Hi, my first time using Github so apologies if I mess this up. This intercepting proxy has been extremely useful. I've encountered a limitation that I couldn't easily find a workaround for so I've adapted the http-express-proxy code to do what I need.

When creating the response during the intercept callback, I needed to use information gained from the request body. I've added a location called 'calleeState' (perhaps there's a better name for it) that allows information to be passed through to the intercept callback on the original request object.

It'd be great to get this change (or something equivalent) into npm so our team can continue updating to the latest version of express-http-proxy.

Many thanks, and great work on the proxy :)
Matt