### PR TITLE
Add preserveHostHdr option to act more like a reverse proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = function proxy(host, options) {
   var forwardPath = options.forwardPath;
   var filter = options.filter;
   var limit = options.limit || '1mb';
+  var preserveHostHdr = options.preserveHostHdr;
 
   return function handleProxy(req, res, next) {
     if (filter && !filter(req, res)) return next();
@@ -53,7 +54,11 @@ module.exports = function proxy(host, options) {
 
     path = forwardPath ? forwardPath(req, res) : url.parse(req.url).path;
 
-    var hds = extend(headers, req.headers, ['connection', 'host', 'content-length']);
+    var skipHdrs = [ 'connection', 'content-length' ];
+    if (!preserveHostHdr) {
+      skipHdrs.push('host');
+    }
+    var hds = extend(headers, req.headers, skipHdrs);
     hds.connection = 'close';
 
     // var hasRequestBody = 'content-type' in req.headers || 'transfer-encoding' in req.headers;


### PR DESCRIPTION
Proposing the addition of this option, so that the host header that the upstream server gets is the same that the one the client originally requested.

This is more like the behavior that nginx provides by default for proxy_pass.

Thanks!
