### PR TITLE
Add preserveReqSession option

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = function proxy(host, options) {
   var filter = options.filter;
   var limit = options.limit || '1mb';
   var preserveHostHdr = options.preserveHostHdr;
+  var preserveReqSession = options.preserveReqSession;
 
   return function handleProxy(req, res, next) {
     if (filter && !filter(req, res)) return next();
@@ -79,6 +80,9 @@ module.exports = function proxy(host, options) {
         params: req.params
       };
 
+      if (preserveReqSession) {
+        reqOpt.session = req.session;
+      }
 
       if (decorateRequest)
         reqOpt = decorateRequest(reqOpt) || reqOpt;

--- a/test/test.js
+++ b/test/test.js
@@ -264,4 +264,27 @@ describe('http-proxy', function() {
     });
   });
 
+  describe('test preserveReqSession', function() {
+    it('preserveReqSession', function(done) {
+      var app = express();
+      app.use(function (req, res, next) {
+        req.session = 'hola';
+        next();
+      });
+      app.use(proxy('httpbin.org', {
+        preserveReqSession: true,
+        decorateRequest: function(req) {
+          assert(req.session, 'hola');
+        }
+      }));
+
+      request(app)
+        .get('/user-agent')
+        .end(function(err, res) {
+          if (err) return done(err);
+          done();
+        });
+    });
+  });
+
 });


### PR DESCRIPTION
Sometime it's useful to get access to request session object in `decorateRequest` function, for instance using [express-session](https://github.com/expressjs/session) to manage the session.

To activate it just add `preserveReqSession` option and set it to `true`.

Example usage here: https://github.com/enricostano/proxy/blob/master/server.js#L28

Would be nice to have a more generic solution, for instance mapping `req` custom objects passed through. I'll further investigate about this but for now this solve the issue.