### PR TITLE
using req.body if it has been pre-parsed

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "type-is": "^1.2.0",
-    "raw-body": "^1.1.6"
+    "raw-body": "^2.1.4"
   },
   "contributors": [
     {


### PR DESCRIPTION
Hi @villadora 

I'm using another library that consumes the `req` in order to validate that the right JSON values have been sent. After tracing it down I found that the proxy was hanging because the `req` was already consumed so no `end` events were being fired (maybe similar to #32) 

Since others might be using a middleware (such as `body-parser` or `swagger-framework`) which pre-process the `req` and put it in `req.body` if the proxy can check for `req.body` and use that if its defined, instead of always consuming the `req` stream, then the proxy can be used with other libraries that pre-decorate the body too.

What do you think?



-------
```
Before:
    test proxy middleware compatibility

  21 passing (11s)
  1 failing

  1) http-proxy test proxy middleware compatibility should use req.body if defined:
     Error: timeout of 10000ms exceeded. Ensure the done() callback is being called in this test.
```

```
After

    test proxy middleware compatibility
      ✓ should use req.body if defined (82ms)

  22 passing (654ms)
```