### PR TITLE
Pass original express 'req' object to decorateRequest

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = function proxy(host, options) {
 
 
       if (decorateRequest)
-        reqOpt = decorateRequest(reqOpt) || reqOpt;
+        reqOpt = decorateRequest(reqOpt, req) || reqOpt;
 
       bodyContent = reqOpt.bodyContent;
       delete reqOpt.bodyContent;


### PR DESCRIPTION
See commit comments for the reasoning behind this. I've passed it in as the 2nd argument to avoid breaking existing implementation.