### PR TITLE
Use url.parse to parse the given host - IP6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "supertest": "^0.13.0"
   },
   "dependencies": {
-    "type-is": "^1.2.0",
+    "lodash.iserror": "^3.1.0",
     "raw-body": "^1.1.6"
   },
   "contributors": [


### PR DESCRIPTION
This changes the meaning of the proxy(`host`, ...) param slightly..

   * a protocol is now required (url.parse needs it), thus https detection depends solely on the protocol
      * port 443 no longer implies https
      * an Error is `next`ed otherwise
   * ipv6 addresses with port are now supported ([::1]:1234 would fail to split before)

Also removed unused `type-is`, and added `lodash.iserror`