### PR TITLE
Preserve body encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ app.use('/proxy', proxy('www.google.com', {
 }));
 ```
 
+#### reqBodyEncoding
+
+Encoding used to decode request body. Default to ```utf-8```.
+
+Use ```null``` to avoid decoding and pass the body as is.
+Accept any values supported by [raw-body](https://www.npmjs.com/package/raw-body#readme).
+
+```
+app.use('/post', proxy('httpbin.org', {
+  reqBodyEncoding: null
+}));
+```
+
 ## Release Notes
 
 | Release | Notes |

--- a/index.js
+++ b/index.js
@@ -64,8 +64,7 @@ module.exports = function proxy(host, options) {
     } else {
       getRawBody(req, {
         length: req.headers['content-length'],
-        limit: limit,
-        encoding: 'utf-8'
+        limit: limit
       }, runProxy);
     }
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = function proxy(host, options) {
   var limit = options.limit || '1mb';
   var preserveHostHdr = options.preserveHostHdr;
   var preserveReqSession = options.preserveReqSession;
+  var reqBodyEncoding = options.reqBodyEncoding !== undefined ? options.reqBodyEncoding: 'utf-8';
 
   return function handleProxy(req, res, next) {
     if (filter && !filter(req, res)) return next();
@@ -64,7 +65,8 @@ module.exports = function proxy(host, options) {
     } else {
       getRawBody(req, {
         length: req.headers['content-length'],
-        limit: limit
+        limit: limit,
+        encoding: reqBodyEncoding
       }, runProxy);
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,8 @@
 var assert = require('assert');
 var express = require('express');
 var request = require('supertest');
+var fs = require('fs');
+var os = require('os');
 var proxy = require('../');
 
 describe('http-proxy', function() {
@@ -349,5 +351,30 @@ describe('http-proxy', function() {
     });
   });
 
+  describe('test body encoding', function() {
+    it('allow raw data', function(done) {
+      var png_data = new Buffer('89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082', 'hex');
+      var filename = os.tmpdir() + '/express-http-proxy-test-' + Math.floor((Math.random() * 1000) + 1) + '-png-transparent.png';
+      var app = express();
+      app.use(proxy('httpbin.org', {
+        decorateRequest: function(reqOpts, req) {
+          assert((new Buffer(reqOpts.bodyContent).toString('hex')).indexOf(png_data.toString('hex')) >= 0, 'body should contain same data');
+          return reqOpts;
+        }
+      }));
+
+      fs.writeFile(filename, png_data, function(err) {
+        request(app)
+          .post('/post')
+          .attach('image', filename)
+          .end(function(err, res) {
+            fs.unlink(filename);
+            assert.equal(res.body.files.image, 'data:image/png;base64,' + png_data.toString('base64'));
+            done(err);
+          });
+      });
+
+    });
+  });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -357,6 +357,7 @@ describe('http-proxy', function() {
       var filename = os.tmpdir() + '/express-http-proxy-test-' + Math.floor((Math.random() * 1000) + 1) + '-png-transparent.png';
       var app = express();
       app.use(proxy('httpbin.org', {
+        reqBodyEncoding: null,
         decorateRequest: function(reqOpts, req) {
           assert((new Buffer(reqOpts.bodyContent).toString('hex')).indexOf(png_data.toString('hex')) >= 0, 'body should contain same data');
           return reqOpts;


### PR DESCRIPTION
This is needed if you want to be able to send data using multipart/form-data. Otherwise data are altered since the proxy assume an utf-8 encoding.