### PR TITLE
Manage aborted connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,10 @@ module.exports = function proxy(host, options) {
       }
 
       realRequest.end();
+
+      req.on('aborted', function () {
+        realRequest.abort();
+      });
     }
   };
 };


### PR DESCRIPTION
If proxy client request is aborted, proxied request now is aborted too and server stops processing the request.