### PR TITLE
[#104] Fix: Exceptions parsing proxied response causes error: Can't s…

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,11 @@ module.exports = function proxy(host, options) {
               }
             });
           } else {
-            res.send(rspData);
+            // see issue https://github.com/villadora/express-http-proxy/issues/104
+            // Not sure how to automate tests on this line, so be careful when changing.
+            if (!res.headersSent) {
+              res.send(rspData);
+            }
           }
         });
 


### PR DESCRIPTION
…et headers after they are sent.

Do not swallow real (e.g. parsing) issue by covering it up with a Can't set headers error.