### PR TITLE
Add response when calling `forwardPath`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,9 +271,9 @@ function chunkLength(chunks) {
 
 function defaultForwardPathAsync(forwardPath) {
   'use strict';
-  return function(req) {
+  return function(req, res) {
     return new promise.Promise(function(resolve) {
-      resolve(forwardPath(req));
+      resolve(forwardPath(req, res));
     });
   };
 }

--- a/test/forwardPath.js
+++ b/test/forwardPath.js
@@ -42,6 +42,27 @@ describe('forwardPath', function() {
       });
   });
 
+  it('test forwardPath to known path with request and response yields 200', function(done) {
+    var app = express();
+    app.use(proxy('httpbin.org', {
+      forwardPath: function(req, res) {
+        assert.ok(req);
+        assert.ok(res);
+        return '/post';
+      }
+    }));
+
+    request(app)
+      .post('/foobar')
+      .send({
+        mypost: 'hello'
+      })
+      .end(function(err, res) {
+        assert.equal(res.statusCode, 200);
+        done(err);
+      });
+  });
+
   it('test forwardPath to undefined yields 404', function(done) {
     var app = express();
     app.use(proxy('httpbin.org', {


### PR DESCRIPTION
This is part of the API and was broken with 7d6e4f8 see https://github.com/villadora/express-http-proxy/commit/7d6e4f8384ed1de438de92dc92b636c861e934c2#diff-168726dbe96b3ce427e7fedce31bb0bcL32