### PR TITLE
Add hooks for caching responses

### DIFF
--- a/test/readCache.js
+++ b/test/readCache.js
@@ -1,0 +1,42 @@
+var assert = require('assert');
+var express = require('express');
+var request = require('supertest');
+var proxy = require('../');
+
+describe('readCache', function() {
+  'use strict';
+  this.timeout(10000);
+
+  var app;
+
+  beforeEach(function() {
+    app = express();
+    app.use(proxy('httpbin.org'));
+  });
+
+  it('should provide a cached response as though it came from the host', function(done) {
+      app = express();
+      app.use(proxy('httpbin.org',{
+          cacheRead: function (req) {
+            return {
+                headers: {
+                    'X-President': 'Obama'
+                },
+                status: '200',
+                data: {
+                    isCached: 'yes'
+                }
+            }
+          }
+      }));
+    request(app)
+      .get('/get')
+      .end(function(err, res) {
+        if (err) { return done(err); }
+        console.log ('res = ' + JSON.stringify(res));
+        assert(res.headers['X-President'],'Obama');
+        assert.equal(res.body.isCached, 'yes');
+        done(err);
+      });
+  });
+});

--- a/test/readCache.js
+++ b/test/readCache.js
@@ -17,24 +17,25 @@ describe('readCache', function() {
   it('should provide a cached response as though it came from the host', function(done) {
       app = express();
       app.use(proxy('httpbin.org',{
-          cacheRead: function (req) {
-            return {
+          readCache: function (req) {
+            return new Promise (function (resolve, reject) {
+              resolve ({
                 headers: {
-                    'X-President': 'Obama'
+                    'x-president': 'Obama'
                 },
-                status: '200',
+                statusCode: 200,
                 data: {
                     isCached: 'yes'
                 }
-            }
+              });
+            });
           }
       }));
     request(app)
       .get('/get')
       .end(function(err, res) {
         if (err) { return done(err); }
-        console.log ('res = ' + JSON.stringify(res));
-        assert(res.headers['X-President'],'Obama');
+        assert(res.header['x-president'],'Obama');
         assert.equal(res.body.isCached, 'yes');
         done(err);
       });

--- a/test/writeCache.js
+++ b/test/writeCache.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var express = require('express');
+var request = require('supertest');
+var proxy = require('../');
+
+describe('writeCache', function() {
+  'use strict';
+  this.timeout(10000);
+
+  var app;
+
+  it('should receive the request and cache data', function(done) {
+      app = express();
+      app.use(proxy('httpbin.org',{
+          cacheWrite: function (req,cacheData) {
+            assert.equal (cacheData.data.url,'http://httpbin.org/get');
+            assert.equal (cacheData.headers['Content-Type'], 'application/json')
+            assert.equal (cacheData.status,'200');
+          }
+      }));
+    request(app)
+      .get('/get')
+      .end(function(err, res) {
+        if (err) { return done(err); }
+        assert(/node-superagent/.test(res.body.headers['User-Agent']));
+        assert.equal(res.body.url, 'http://httpbin.org/get');
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
This fork adds hooks (readCache and writeCache) that allow the user to cache responses and serve cached responses if they exist. It is up to the user to implement the caching system, this simply provides the hooks.

I'm using this in a project to cache WMTS requests and it works great.