### PR TITLE
Custom cert chain option for underlying request

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,25 @@ app.use('/', proxy('httpbin.org', {
 }));
 ```
 
+#### optionalCertAuthority
+
+This is a certificate object or array of certificate objects (just like what you'd pass to the https agent for a normal request). Use this to connect to hosts with https that use internal or known, self-signed certificates.
+
+```js
+var caCert = fs.readFileSync('certs/root-cert.crt');
+var intermediaryCert = fs.readFileSync('certs/intermediary-cert.crt');
+
+app.use('/', proxy('internalhost.example.com', {
+  optionalCertAuthority: {
+    [caCert, intermediaryCert]
+  } 
+}));
+
+```
+
+
+
+
 
 ## Questions
 

--- a/index.js
+++ b/index.js
@@ -33,13 +33,14 @@ module.exports = function proxy(host, options) {
     prepareRequest.then(function(results) {
       var path = results[0];
       var bodyContent = results[1];
-      sendProxyRequest(req, res, next, path, bodyContent);
+      sendProxyRequest(req, res, next, path, bodyContent, options.optionalCertAuthority);
     });
   };
 
 
-  function sendProxyRequest(req, res, next, path, bodyContent) {
+  function sendProxyRequest(req, res, next, path, bodyContent, optionalCertAuthority) {
     parsedHost = parsedHost || parseHost(host, req, options);
+
 
     var reqOpt = {
       hostname: parsedHost.host,
@@ -50,6 +51,10 @@ module.exports = function proxy(host, options) {
       bodyContent: bodyContent,
       params: req.params,
     };
+
+    if (optionalCertAuthority) {
+      reqOpt.ca = optionalCertAuthority;
+    }
 
     if (preserveReqSession) {
       reqOpt.session = req.session;


### PR DESCRIPTION
Add an additional option so you can pass certificates through
to the underlying request, for connecting to hosts with non-standard
or custom certificate chains.