### PR TITLE
[major refactor] Separate workflow steps into methods;  attmept to cl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,34 +130,64 @@ first request.
 
 #### decorateRequest
 
-You can change the request options before it is sent to the target.   
+REMOVED:  See ```decorateReqOpt``` and ```decorateReqBody```.
+
+#### decorateReqOpt
+
+You can mutate the request options before sending the proxyRequest.
 
 ```js
 app.use('/proxy', proxy('www.google.com', {
-  decorateRequest: function(proxyReq, originalReq) {
+  decorateReqOpt: function(proxyReq, srcReq) {
     // you can update headers
     proxyReq.headers['Content-Type'] = 'text/html';
     // you can change the method
     proxyReq.method = 'GET';
-    // you can munge the bodyContent.
-    proxyReq.bodyContent = proxyReq.bodyContent.replace(/losing/, 'winning!');
+    // you could change the path
+    proxyReq.path = 'http://dev/null'
     return proxyReq;
   }
 }));
 ```
 
-Use a Promise for async decorations.
+You can use a Promise for async style.
 
 ```js
 app.use('/proxy', proxy('www.google.com', {
-  decorateRequest: function(proxyReq, originalReq) {
+  decorateReqOpt: function(proxyReq, srcReq) {
     return new Promise(function(resolve, reject) {
-      proxyReq.bodyContent = proxyReq.bodyContent.replace(/losing/, 'winning!');
+      proxyReq.headers['Content-Type'] = 'text/html';
       resolve(proxyReq);
     })
   }
 }));
+```
 
+#### decorateReqBody
+
+You can mutate the body content before sending the proxyRequest.
+
+```js
+app.use('/proxy', proxy('www.google.com', {
+  decorateReqBody: function(bodyContent, srcReq) {
+    return bodyContent.split('').reverse().join('');
+  }
+}));
+```
+
+You can use a Promise for async style.
+
+```js
+app.use('/proxy', proxy('www.google.com', {
+  decorateReqBody: function(proxyReq, srcReq) {
+    return new Promise(function(resolve, reject) {
+      http.get('http://dev/null', function (err, res) {
+        if (err) { reject(err); }
+        resolve(res);
+      });
+    })
+  }
+}));
 ```
 
 #### https
@@ -276,7 +306,8 @@ Then inside the decorateRequest method, add the agent to the request:
 
 | Release | Notes |
 | --- | --- |
-| 0.11.1 | Allow author to prevent host from being memoized between requests.   General program cleanup. |
+| UNRELEASED MAJOR REV | REMOVE decorateRequest, ADD decorateReqOpts and decorateReqBody |
+| 0.11.0 | Allow author to prevent host from being memoized between requests.   General program cleanup. |
 | 0.10.1| Fixed issue where 'body encoding' was being incorrectly set to the character encoding. <br />  Dropped explicit support for node 0.10. <br />   Intercept can now deal with gziped responses. <br />   Author can now 'force https', even if the original request is over http. <br />  Do not call next after ECONNRESET catch. |
 | 0.10.0 | Fix regression in forwardPath implementation. |
 | 0.9.1 | Documentation updates.  Set 'Accept-Encoding' header to match bodyEncoding. |

--- a/index.js
+++ b/index.js
@@ -1,23 +1,17 @@
 'use strict';
 
-// ROADMAP:
+// ROADMAP: Major refactoring April 2017
 // There are a lot of competing strategies in this code.
 // It would be easier to follow if we extract to simpler functions, and used
 // a standard, step-wise set of filters with clearer edges and borders.
 // Currently working on identifying through comments the workflow steps.
 
-// I think I could extract reqBody and reqOpt to classes
-
-// I think this might be a good pattern to work toward.
-// might have to partially apply a lot of arguments up top
-//filterRequest(req)
-  //.then(createProxyRequestOptions)
-  //.then(decorateProxyRequestOptions)
-  //.then(decorateProxyRequestBody)
-  //.then(makeProxyRequest)
-  //.then(decorateProxyResponse)
-  //.then(sendUserResponse);
-  //.catch(next)
+// Phase 1: in progress, nearly complete: Break workflow into composable steps without changing them much
+// Phase 2: extract workflow methods from main file
+// Phase 3: cleanup workflow methods so they all present as over-rideable thennables
+// Phase 4: cleanup options interface
+// Update/add tests to unit test workflow steps independently
+// Phase 4: update docs and release
 
 var assert = require('assert');
 var http = require('http');
@@ -28,51 +22,68 @@ var requestOptions = require('./lib/requestOptions');
 var isUnset = require('./lib/isUnset');
 var chunkLength = require('./lib/chunkLength');
 
+// The original program relied on a multi-nested closure to provide access to all these
+// variables in scope.
+// In order to separate them (prior to standarding interfaces), I'm making a scope container.
+// This may be transitional, and I want to hide the details of this from hooks
+var Container = {
+  user: {
+    req: {},
+    res: {},
+    next: null,
+  },
+  proxy: {
+    req: {},
+    res: {},
+    bodyContent: {},
+    reqBuilder: {}
+  },
+  options: {}
+};
+
 module.exports = function proxy(host, options) {
   assert(host, 'Host should not be empty');
 
   // move options into an external constructor
   options = options || {};
 
-  //var parsedHost;
-
   /**
    * Function :: intercept(targetResponse, data, res, req, function(err, json, sent));
    */
-  var intercept = options.intercept;
-  var decorateRequest = options.decorateRequest || function(reqOpt) { return reqOpt; };
   var forwardPath = options.forwardPath || defaultForwardPath;
   var decorateReqPath = options.forwardPathAsync || defaultForwardPathAsync(forwardPath);
   var filter = options.filter || defaultFilter;
+  var decorateReqOpt = options.decorateReqOpt || function(reqOpt /*, req */) { return reqOpt; };
+  var decorateReqBody = options.decorateReqBody || function(bodyContent /*, req*/) { return bodyContent; };
+
+  if (options.decorateRequest) {
+    throw new Error('decorateRequest is deprecated; use decorateReqOpt and decorateReqBody instead');
+  }
 
   // For backwards compatability, we default to legacy behavior for newly added settings.
   var parseReqBody = isUnset(options.parseReqBody) ? true : options.parseReqBody;
 
   // need to get decorateReqPath and decorateRequest off this scope so I can move this
-  function decorateRequestWrapper(reqOpt, req, bodyContent) {
-    // This is just because of a legacy expectation that decorateRequest be
-    // handed the bodyContent on reqOpts. Split this up next.
-    if (parseReqBody) {
-      reqOpt.bodyContent = bodyContent;
-    }
+  function decorateRequestWrapper(Container) {
 
     return new Promise(function(resolve) {
-      Promise
-        .all([
-          decorateReqPath(req),   // resolve path
-          // split up into bodyContent and reqOpt in future commit
-          decorateRequest(reqOpt, req),  // resolve decorateRequestHook
+      Promise.all([
+          decorateReqPath(Container.user.req),
+          decorateReqOpt(Container.proxy.reqBuilder, Container.user.req),
+          decorateReqBody(Container.proxy.bodyContent, Container.user.req)
         ])
         .then(function(values) {
           var path = values[0];
           var reqOpt = values[1];
-          var bodyContent = reqOpt.bodyContent;
+          var bodyContent = values[2];
 
-          delete reqOpt.bodyContent;
+          if (typeof reqOpt !== 'object') {
+            throw new ReferenceError('decorateReqOpt must return an Object.');
+          }
+
           reqOpt.path = path;
 
-          // NOTE: at this point, if parseReqBody is false, bodyContent is undefined.  could simplify this logic
-          if (parseReqBody) {
+          if (bodyContent) {
             bodyContent = options.reqAsBuffer ?
               asBuffer(bodyContent, options) :
               asBufferOrString(bodyContent);
@@ -86,126 +97,70 @@ module.exports = function proxy(host, options) {
 
           delete reqOpt.params;
 
+          Container.proxy.reqBuilder = reqOpt;
+          Container.proxy.bodyContent = bodyContent;
           // still need to resolve the bodyContent stuff
-          resolve([reqOpt, bodyContent]);
+          resolve(Container);
         });
     });
   }
 
-  return function handleProxy(req, res, next) {
-    // Do not proxy request if filter returns false.
-    if (!filter(req, res)) { return next(); }
+  function buildProxyReq(Container) {
+    var req = Container.user.req;
+    var res = Container.user.res;
+    var options = Container.options;
 
     var parseBody = (!parseReqBody) ? Promise.resolve(null) : requestOptions.bodyContent(req, res, options);
     var createReqOptions = requestOptions.create(req, res, options, host);
 
-    var buildProxyReq = Promise.all([
-      parseBody,
-      createReqOptions
-    ]);
-
-    // ProxyRequestPair // { settings, body }
-    buildProxyReq.then(function(results) {
-      var bodyContent = results[0];
-      var reqOpt = results[1];
-
-
-      Promise
-        // Pattern:   always call the maybe function; have a default noop.
-        // Pattern:   use Promise.resolve here to avoid having to guess if its a promise or not.
-        .resolve(decorateRequestWrapper(reqOpt, req, bodyContent))
-        .then(function(responseArray) {
-          var processedReqOpt = responseArray[0];
-          var bodyContent = responseArray[1];
-
-          if (typeof processedReqOpt !== 'object') {
-            throw new ReferenceError('decorateRequest must return an Object.');
-          }
-
-          // WIP: req, res, and next are not needed until the callback method.
-          // split into a thennable
-          /**** [
-            SEND PROXY REQUEST
-          ] ****/
-          sendProxyRequest(req, res, next, bodyContent, processedReqOpt)
-            .then(function(proxyResponse) {
-              var rsp = proxyResponse[0];
-              var rspData = proxyResponse[1];
-
-              if (!res.headersSent) {
-                res.status(rsp.statusCode);
-                Object.keys(rsp.headers)
-                  .filter(function(item) { return item !== 'transfer-encoding'; })
-                  .forEach(function(item) {
-                    res.set(item, rsp.headers[item]);
-                  });
-              }
-
-              function postIntercept(res, next, rspData) {
-                return function(err, rspd, sent) {
-                  if (err) {
-                    return next(err);
-                  }
-                  rspd = asBuffer(rspd, options);
-                  rspd = maybeZipResponse(rspd, res);
-
-                  if (!Buffer.isBuffer(rspd)) {
-                    next(new Error('intercept should return string or' +
-                          'buffer as data'));
-                  }
-
-                  // TODO: return rspd here
-
-                  // afterIntercept
-                  if (!res.headersSent) {
-                    res.set('content-length', rspd.length);
-                  } else if (rspd.length !== rspData.length) {
-                    var error = '"Content-Length" is already sent,' +
-                          'the length of response data can not be changed';
-                    next(new Error(error));
-                  }
-
-                  //  returns res to user
-                  if (!sent) {
-                    res.send(rspd);
-                  }
-                };
-              }
-
-              // maybe this should actually use a wrapper pattern.
-              // if (intercept)
-              //   beforeIntercept()
-              //   intercept()
-              //   afterIntercept();
-
-              if (intercept) {
-                // beforeIntercept
-                rspData = maybeUnzipResponse(rspData, res);
-                var callback = postIntercept(res, next, rspData);
-                intercept(rsp, rspData, req, res, callback);
-              } else {
-                // see issue https://github.com/villadora/express-http-proxy/issues/104
-                // Not sure how to automate tests on this line, so be careful when changing.
-                if (!res.headersSent) {
-                  res.send(rspData);
-                }
-              }
-            });
-
-
-        })
-        .catch(next);
+   return new Promise(function(resolve) {
+     Promise
+      .all([parseBody, createReqOptions])
+      .then(function(responseArray) {
+        Container.proxy.bodyContent = responseArray[0];
+        Container.proxy.reqBuilder = responseArray[1];
+        resolve(Container);
+      });
     });
+  }
+
+  return function handleProxy(req, res, next) {
+    Container.user.req = req;
+    Container.user.res = res;
+    Container.user.next = next;
+    Container.options = options; // TODO: move up, and capture functionality that coerces hooks to methods
+
+    // Do not proxy request if filter returns false.
+    if (!filter(req, res)) { return next(); }
+
+    buildProxyReq(Container)
+      .then(decorateRequestWrapper) // the wrapper around request decorators.  this could use a better name
+      .then(sendProxyRequest)
+      //.then(copyProxyResToUserRes)
+      .then(decorateUserRes)
+      .then(sendUserRes)
+      .catch(next);
   };
 
-  function sendProxyRequest(req, res, next, bodyContent, reqOpt) {
+
+  function sendProxyRequest(Container) {
+      var req = Container.user.req;
+      var res = Container.user.res;
+      var bodyContent = Container.proxy.bodyContent;
+      var reqOpt = Container.proxy.reqBuilder;
+      var options = Container.options;
+
       return new Promise(function(resolve, reject) {
         var protocol = parseHost(host, req, options).module;
         var proxyReq = protocol.request(reqOpt, function(rsp) {
           var chunks = [];
           rsp.on('data', function(chunk) { chunks.push(chunk); });
-          rsp.on('end', function()       { resolve([rsp, Buffer.concat(chunks, chunkLength(chunks))]); });
-          rsp.on('error', function(err)  { reject(err); });
+          rsp.on('end', function() {
+            Container.proxy.res = rsp;
+            Container.proxy.resData = Buffer.concat(chunks, chunkLength(chunks));
+            resolve(Container);
+          });
+          rsp.on('error', reject);
         });
 
         proxyReq.on('socket', function(socket) {
@@ -216,6 +171,7 @@ module.exports = function proxy(host, options) {
           }
         });
 
+        // TODO: do reject here and handle this later on
         proxyReq.on('error', function(err) {
           // reject(error);
           if (err.code === 'ECONNRESET') {
@@ -225,10 +181,11 @@ module.exports = function proxy(host, options) {
             res.writeHead(504, {'Content-Type': 'text/plain'});
             res.end();
           } else {
-            next(err);
+            reject(err);
           }
         });
 
+        // this guy should go elsewhere, down the chain
         if (parseReqBody) {
           // We are parsing the body ourselves so we need to write the body content
           // and then manually end the request.
@@ -358,3 +315,88 @@ function zipOrUnzip(method) {
 
 var maybeUnzipResponse = zipOrUnzip('gunzipSync');
 var maybeZipResponse = zipOrUnzip('gzipSync');
+
+function decorateUserRes(Container) {
+    var rsp = Container.proxy.res;
+    var res = Container.user.res;
+    var rspData = Container.proxy.resData;
+    var intercept = Container.options.intercept;
+    var next = Container.user.next;
+    var req = Container.user.req;
+
+    if (!res.headersSent) {
+        res.status(rsp.statusCode);
+        Object.keys(rsp.headers)
+        .filter(function(item) { return item !== 'transfer-encoding'; })
+        .forEach(function(item) {
+            res.set(item, rsp.headers[item]);
+        });
+    }
+
+    function postIntercept(res, next, rspData) {
+       // TODO: handle sent?  or is res.headersSent enough?
+        return function(err, rspd /*, sent */) {
+            if (err) {
+                return next(err);
+            }
+            rspd = asBuffer(rspd, Container.options);
+            rspd = maybeZipResponse(rspd, res);
+
+            if (!Buffer.isBuffer(rspd)) {
+                next(new Error('intercept should return string or' +
+                    'buffer as data'));
+            }
+
+            // TODO: return rspd here
+
+            // afterIntercept
+            if (!res.headersSent) {
+                res.set('content-length', rspd.length);
+            } else if (rspd.length !== rspData.length) {
+                var error = '"Content-Length" is already sent,' +
+                    'the length of response data can not be changed';
+                next(new Error(error));
+            }
+            Container.user.res = res;
+            Container.proxy.resData = rspd;
+            return Container;
+            //if (!sent) {
+                //res.send(rspd);
+            //}
+        };
+    }
+
+    // maybe this should actually use a wrapper pattern.
+    // if (intercept)
+    //   beforeIntercept()
+    //   intercept()
+    //   afterIntercept();
+
+    if (intercept) {
+        // beforeIntercept
+        rspData = maybeUnzipResponse(rspData, res);
+        var callback = postIntercept(res, next, rspData);
+        Promise.resolve(intercept(rsp, rspData, req, res, callback));
+    } else {
+        Promise.resolve(Container);
+        // see issue https://github.com/villadora/express-http-proxy/issues/104
+        // Not sure how to automate tests on this line, so be careful when changing.
+        //if (!res.headersSent) {
+            //res.send(rspData);
+        //}
+    }
+
+
+    return Container;
+}
+
+function sendUserRes(Container) {
+    Promise.resolve(Container);
+    //debugger;
+    if (!Container.user.res.headersSent) {
+        Container.user.res.send(Container.proxy.resData);
+    }
+    Promise.resolve(Container);
+}
+
+

--- a/test/bodyEncoding.js
+++ b/test/bodyEncoding.js
@@ -28,10 +28,10 @@ describe('body encoding', function() {
 
     app.use(proxy('localhost:8109', {
       reqBodyEncoding: null,
-      decorateRequest: function(reqOpts) {
-        assert((new Buffer(reqOpts.bodyContent).toString('hex')).indexOf(pngData.toString('hex')) >= 0,
-          'body should contain original raw data');
-        return reqOpts;
+      decorateReqBody: function(bodyContent) {
+        assert((new Buffer(bodyContent).toString('hex')).indexOf(pngData.toString('hex')) >= 0,
+          'body should contain same data');
+        return bodyContent;
       }
     }));
 
@@ -60,9 +60,9 @@ describe('body encoding', function() {
       var app = express();
       app.use(proxy('localhost:8109', {
         parseReqBody: false,
-        decorateRequest: function(reqOpts) {
-          assert(!reqOpts.bodyContent, 'body content should not be parsed.');
-          return reqOpts;
+        decorateReqBody: function(bodyContent) {
+          assert(!bodyContent, 'body content should not be parsed.');
+          return bodyContent;
         }
       }));
 

--- a/test/decorateRequest.js
+++ b/test/decorateRequest.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var express = require('express');
+var http = require('http');
 var request = require('supertest');
 var proxy = require('../');
 
@@ -17,13 +18,13 @@ describe('decorateRequest', function() {
 
   describe('Supports Promise and non-Promise forms', function() {
 
-    describe('when decorateRequest is a simple function (non Promise)', function() {
+    describe('when decorateReqOpts is a simple function (non Promise)', function() {
       it('should mutate the proxied request', function(done) {
         var app = express();
         app.use(proxy('httpbin.org', {
-          decorateRequest: function(reqOpt, req) {
+          decorateReqOpt: function(reqOpt, req) {
             reqOpt.headers['user-agent'] = 'test user agent';
-            assert(req);
+            assert(req instanceof http.IncomingMessage);
             return reqOpt;
           }
         }));
@@ -38,12 +39,12 @@ describe('decorateRequest', function() {
       });
     });
 
-    describe('when decorate request is a Promise', function() {
+    describe('when decorateReqOpt is a Promise', function() {
       it('should mutate the proxied request', function(done) {
         var app = express();
         app.use(proxy('httpbin.org', {
-          decorateRequest: function(reqOpt, req) {
-            assert(req);
+          decorateReqOpt: function(reqOpt, req) {
+            assert(req instanceof http.IncomingMessage);
             return new Promise(function(resolve) {
               reqOpt.headers['user-agent'] = 'test user agent';
               resolve(reqOpt);
@@ -62,11 +63,12 @@ describe('decorateRequest', function() {
     });
   });
 
-  describe('decorateRequest has access to the source request\'s data', function() {
+  describe('decorateReqOpt has access to the source request\'s data', function() {
     it('should have access to ip', function(done) {
       var app = express();
       app.use(proxy('httpbin.org', {
-        decorateRequest: function(reqOpts, req) {
+        decorateReqOpt: function(reqOpts, req) {
+          assert(req instanceof http.IncomingMessage);
           assert(req.ip);
           return reqOpts;
         }

--- a/test/intercept.js
+++ b/test/intercept.js
@@ -133,7 +133,7 @@ describe('test intercept on html response from github',function() {
   'use strict';
 
   it('is able to read and manipulate the response', function(done) {
-    this.timeout(1500);  // give it some extra time to get response
+    this.timeout(15000);  // give it some extra time to get response
     var app = express();
     app.use(proxy('https://github.com/villadora/express-http-proxy', {
       intercept: function(targetResponse, data, req, res, cb) {

--- a/test/session.js
+++ b/test/session.js
@@ -23,8 +23,8 @@ describe('preserveReqSession', function() {
     });
     app.use(proxy('httpbin.org', {
       preserveReqSession: true,
-      decorateRequest: function(req) {
-        assert(req.session, 'hola');
+      decorateReqOpts: function(reqOpts, req) {
+        assert(reqOpts.session, 'hola');
         return req;
       }
     }));

--- a/test/support/proxyTarget.js
+++ b/test/support/proxyTarget.js
@@ -20,7 +20,6 @@ function proxyTarget(port, timeout) {
     //req.on('data', function(chunk) { chunks.push(chunk); });
     //req.on('end', function()       {
       //var upload = Buffer.concat(chunks, chunkLength(chunks));
-      //debugger;
       //res.write(upload);
       //res.end();
       //res.json({


### PR DESCRIPTION
…arify boundaries.  Prep for standardizing workflow steps into thennables.

REMOVES decorateRequest, ADDS decorateReqOpt and decorateReqBody.   This paves the way for pluggable bodyContent handlers, which has been a theme recently.