### PR TITLE
Make decorate request steps sequential

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,16 @@ app.use('/proxy', proxy('www.google.com', {
 
 #### intercept
 
-You can intercept the response before sending it back to the client.
+You can intercept the response before sending it back to the client.   You must
+return the callback at the end of your operation.
 
 ```js
 app.use('/proxy', proxy('www.google.com', {
   intercept: function(rsp, data, req, res, callback) {
     // rsp - original response from the proxy
     data = JSON.parse(data.toString('utf8'));
-    callback(null, JSON.stringify(data));
+    // YOU MUST return the callback, or your request will silently die here.
+    return callback(null, JSON.stringify(data));
   }
 }));
 ```
@@ -336,7 +338,7 @@ Then inside the decorateRequest method, add the agent to the request:
 
 | Release | Notes |
 | --- | --- |
-| UNRELEASED MAJOR REV | REMOVE decorateRequest, ADD decorateProxyReqOpts and decorateProxyReqBody |
+| UNRELEASED MAJOR REV | REMOVE decorateRequest, ADD decorateProxyReqOpts and decorateProxyReqBody.   intercept hook now REQUIRES you to return the cb method. |
 | 0.11.0 | Allow author to prevent host from being memoized between requests.   General program cleanup. |
 | 0.10.1| Fixed issue where 'body encoding' was being incorrectly set to the character encoding. <br />  Dropped explicit support for node 0.10. <br />   Intercept can now deal with gziped responses. <br />   Author can now 'force https', even if the original request is over http. <br />  Do not call next after ECONNRESET catch. |
 | 0.10.0 | Fix regression in forwardPath implementation. |

--- a/app/steps/decorateProxyReqOpts.js
+++ b/app/steps/decorateProxyReqOpts.js
@@ -10,6 +10,7 @@ function decorateProxyReqOpt(container) {
   return Promise
     .resolve(resolverFn(container.proxy.reqBuilder, container.user.req))
     .then(function(processedReqOpts) {
+        delete processedReqOpts.params;
         container.proxy.reqBuilder = processedReqOpts;
         return Promise.resolve(container);
     });

--- a/app/steps/prepareProxyReq.js
+++ b/app/steps/prepareProxyReq.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var as = require('../../lib/as');
+
+function getContentLength(body) {
+
+  var result;
+  if (Buffer.isBuffer(body)) { // Buffer
+    result = body.length;
+  } else if (typeof body === 'string') {
+    result = Buffer.byteLength(body);
+  }
+  return result;
+}
+
+
+function prepareProxyReq(container) {
+  return new Promise(function(resolve) {
+    var bodyContent = container.proxy.bodyContent;
+    var reqOpt = container.proxy.reqBuilder;
+
+    if (bodyContent) {
+
+      bodyContent = container.options.reqAsBuffer ?
+        as.buffer(bodyContent, container.options) :
+        as.bufferOrString(bodyContent);
+
+      reqOpt.headers['content-length'] = getContentLength(bodyContent);
+
+      if (container.options.reqBodyEncoding) {
+        reqOpt.headers['Accept-Charset'] = container.options.reqBodyEncoding;
+      }
+    }
+
+
+    container.proxy.bodyContent = bodyContent;
+    resolve(container);
+  });
+}
+
+module.exports = prepareProxyReq;
+

--- a/index.js
+++ b/index.js
@@ -15,11 +15,14 @@
 var ScopeContainer = require('./lib/scopeContainer');
 var assert = require('assert');
 var buildProxyReq = require('./lib/buildProxyReq');
-var decorateRequestWrapper = require('./lib/decorateRequestWrapper');
 var decorateUserRes = require('./lib/decorateUserRes');
 var resolveProxyHost = require('./lib/resolveProxyHost');
 var sendProxyRequest = require('./lib/sendProxyRequest');
 var sendUserRes = require('./lib/sendUserRes');
+var resolveProxyReqPath = require('./app/steps/resolveProxyReqPath');
+var decorateProxyReqOpts = require('./app/steps/decorateProxyReqOpts');
+var decorateProxyReqBody = require('./app/steps/decorateProxyReqBody');
+var prepareProxyReq = require('./app/steps/prepareProxyReq');
 
 module.exports = function proxy(host, userOptions) {
   assert(host, 'Host should not be empty');
@@ -38,13 +41,11 @@ module.exports = function proxy(host, userOptions) {
     // workflow steps with a Promise or simple function.
     buildProxyReq(Container)
       .then(resolveProxyHost)
-      //.then(resolveProxyPath)
-      //.then(decorateProxyReqOpts)
-      //.then(decorateProxyReqBody)
-      .then(decorateRequestWrapper) // the wrapper around request decorators.  this could use a better name
-      //.then(prepareProxyReq)
+      .then(decorateProxyReqOpts)
+      .then(resolveProxyReqPath)
+      .then(decorateProxyReqBody)
+      .then(prepareProxyReq)
       .then(sendProxyRequest)
-      //.then(copyProxyResToUserRes)
       .then(decorateUserRes)
       .then(sendUserRes)
       .catch(next);

--- a/lib/decorateUserRes.js
+++ b/lib/decorateUserRes.js
@@ -22,33 +22,35 @@ function decorateUserRes(Container) {
     function postIntercept(res, next, rspData) {
        // TODO: handle sent?  or is res.headersSent enough?
         return function(err, rspd /*, sent */) {
-            if (err) {
-                return next(err);
-            }
-            rspd = as.buffer(rspd, Container.options);
-            rspd = maybeZipResponse(rspd, res);
+          return new Promise(function(resolve) {
+              if (err) {
+                  return next(err);
+              }
+              rspd = as.buffer(rspd, Container.options);
+              rspd = maybeZipResponse(rspd, res);
 
-            if (!Buffer.isBuffer(rspd)) {
-                next(new Error('intercept should return string or' +
-                    'buffer as data'));
-            }
+              if (!Buffer.isBuffer(rspd)) {
+                  next(new Error('intercept should return string or' +
+                      'buffer as data'));
+              }
 
-            // TODO: return rspd here
+              // TODO: return rspd here
 
-            // afterIntercept
-            if (!res.headersSent) {
-                res.set('content-length', rspd.length);
-            } else if (rspd.length !== rspData.length) {
-                var error = '"Content-Length" is already sent,' +
-                    'the length of response data can not be changed';
-                next(new Error(error));
-            }
-            Container.user.res = res;
-            Container.proxy.resData = rspd;
-            return Container;
-            //if (!sent) {
-                //res.send(rspd);
-            //}
+              // afterIntercept
+              if (!res.headersSent) {
+                  res.set('content-length', rspd.length);
+              } else if (rspd.length !== rspData.length) {
+                  var error = '"Content-Length" is already sent,' +
+                      'the length of response data can not be changed';
+                  next(new Error(error));
+              }
+              Container.user.res = res;
+              Container.proxy.resData = rspd;
+              resolve(Container);
+              //if (!sent) {
+                  //res.send(rspd);
+              //}
+            });
         };
     }
 
@@ -62,9 +64,9 @@ function decorateUserRes(Container) {
         // beforeIntercept
         rspData = maybeUnzipResponse(rspData, res);
         var callback = postIntercept(res, next, rspData);
-        Promise.resolve(intercept(rsp, rspData, req, res, callback));
+        return intercept(rsp, rspData, req, res, callback);
     } else {
-        Promise.resolve(Container);
+        return Promise.resolve(Container);
         // see issue https://github.com/villadora/express-http-proxy/issues/104
         // Not sure how to automate tests on this line, so be careful when changing.
         //if (!res.headersSent) {
@@ -73,7 +75,7 @@ function decorateUserRes(Container) {
     }
 
 
-    return Container;
+    //return Container;
 }
 
 function isResGzipped(res) {

--- a/lib/sendProxyRequest.js
+++ b/lib/sendProxyRequest.js
@@ -48,6 +48,13 @@ function sendProxyRequest(Container) {
     if (options.parseReqBody) {
     // We are parsing the body ourselves so we need to write the body content
     // and then manually end the request.
+
+      //if (bodyContent instanceof Object) {
+        //throw new Error
+        //debugger;
+        //bodyContent = JSON.stringify(bodyContent);
+      //}
+
       if (bodyContent.length) {
         proxyReq.write(bodyContent);
       }

--- a/lib/sendUserRes.js
+++ b/lib/sendUserRes.js
@@ -1,11 +1,10 @@
 'use strict';
 
 function sendUserRes(Container) {
-  Promise.resolve(Container);
   if (!Container.user.res.headersSent) {
-      Container.user.res.send(Container.proxy.resData);
+    Container.user.res.send(Container.proxy.resData);
   }
-  Promise.resolve(Container);
+  return Promise.resolve(Container);
 }
 
 

--- a/test/intercept.js
+++ b/test/intercept.js
@@ -1,10 +1,11 @@
+'use strict';
+
 var assert = require('assert');
 var express = require('express');
 var request = require('supertest');
 var proxy = require('../');
 
 describe('intercept', function() {
-  'use strict';
 
   it('has access to original response', function(done) {
     var app = express();
@@ -27,7 +28,7 @@ describe('intercept', function() {
       intercept: function(rsp, data, req, res, cb) {
         data = JSON.parse(data.toString('utf8'));
         data.intercepted = true;
-        cb(null, JSON.stringify(data));
+        return cb(null, JSON.stringify(data));
       }
     }));
 
@@ -35,6 +36,7 @@ describe('intercept', function() {
     .get('/ip')
     .end(function(err, res) {
       if (err) { return done(err); }
+
       assert(res.body.intercepted);
       done();
     });
@@ -47,7 +49,7 @@ describe('intercept', function() {
       intercept: function(rsp, data, req, res, cb) {
         res.set('x-wombat-alliance', 'mammels');
         res.set('content-type', 'wiki/wiki');
-        cb(null, data);
+        return cb(null, data);
       }
     }));
 
@@ -67,7 +69,7 @@ describe('intercept', function() {
       intercept: function(rsp, data, req, res, cb) {
         data = data.toString().replace('Oh', '<strong>Hey</strong>');
         assert(data !== '');
-        cb(null, data);
+        return cb(null, data);
       }
     }));
 
@@ -130,8 +132,6 @@ describe('test intercept on html response from github',function() {
      issue.
   */
 
-  'use strict';
-
   it('is able to read and manipulate the response', function(done) {
     this.timeout(15000);  // give it some extra time to get response
     var app = express();
@@ -139,7 +139,7 @@ describe('test intercept on html response from github',function() {
       intercept: function(targetResponse, data, req, res, cb) {
         data = data.toString().replace('DOCTYPE','WINNING');
         assert(data !== '');
-        cb(null, data);
+        return cb(null, data);
       }
     }));
 

--- a/test/support/proxyTarget.js
+++ b/test/support/proxyTarget.js
@@ -1,11 +1,18 @@
 'use strict';
 
 var express = require('express');
+var bodyParser = require('body-parser');
 
 function proxyTarget(port, timeout, handlers) {
   var target = express();
 
-  timeout = 1000 || timeout;
+  timeout = timeout || 100;
+
+  // parse application/x-www-form-urlencoded
+  target.use(bodyParser.urlencoded({ extended: false }));
+
+  // parse application/json
+  target.use(bodyParser.json());
 
   target.use(function(req, res, next) {
     setTimeout(function() {
@@ -23,14 +30,14 @@ function proxyTarget(port, timeout, handlers) {
     req.pipe(res);
   });
 
-  target.use(function(err, req, res) {
+  target.use(function(err, req, res, next) {
     res.send(err);
+    next();
   });
 
   target.use(function(req, res) {
     res.sendStatus(404);
   });
-
 
   return target.listen(port);
 }


### PR DESCRIPTION
…ts sequential to avoid issues with passed-by-reference 'container'.

Extract prepareProxyReq as a separate module