### PR TITLE
Use follow-redirects instead of default http to support redirecting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 
 # no Webstorm info at all
 .idea/*
+*.iml

--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -42,7 +42,7 @@ function parseHost(Container) {
     return new Error('Unable to parse hostname, possibly missing protocol://?');
   }
 
-  var ishttps = options.https || parsed.protocol === 'https:';
+  var ishttps = options.https || parsed.protocol === 'https:' || req.headers['cloudfront-forwarded-proto'] === 'https';
 
   return {
     host: parsed.hostname,

--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -1,6 +1,8 @@
 'use strict';
-var http = require('http');
-var https = require('https');
+
+const followRedirects = require("follow-redirects")
+var http = followRedirects.http
+var https = followRedirects.https
 var url = require('url');
 var getRawBody = require('raw-body');
 var isUnset = require('./isUnset');

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "winston": "^2.3.1",
-    "follow-redirects": "^1.2.3"
+    "follow-redirects": "^1.2.3",
     "debug": "^3.0.1",
     "es6-promise": "^4.1.1",
     "raw-body": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "debug": "^2.6.4",
     "es6-promise": "^3.3.1",
     "raw-body": "^2.2.0",
-    "winston": "^2.3.1"
+    "winston": "^2.3.1",
+    "follow-redirects": "^1.2.3"
   },
   "contributors": [
     {


### PR DESCRIPTION
With this lib, the proxy will fully support websites that use redirects (like google.com) and still proxy the site correctly (without this the browser will redirect and stop using the proxy).