### PR TITLE
Prevent unhandled promise rejection error when body size exceeds limit

### DIFF
--- a/app/steps/buildProxyReq.js
+++ b/app/steps/buildProxyReq.js
@@ -12,16 +12,14 @@ function buildProxyReq(Container) {
   var parseBody = (!options.parseReqBody) ? Promise.resolve(null) : requestOptions.bodyContent(req, res, options);
   var createReqOptions = requestOptions.create(req, res, options, host);
 
-  return new Promise(function(resolve) {
-    Promise
+  return Promise
     .all([parseBody, createReqOptions])
     .then(function(responseArray) {
       Container.proxy.bodyContent = responseArray[0];
       Container.proxy.reqBuilder = responseArray[1];
       debug('proxy request options:\n', Container.proxy.reqBuilder);
-      resolve(Container);
+      return Container;
     });
-  });
 }
 
 module.exports = buildProxyReq;

--- a/test/bodyEncoding.js
+++ b/test/bodyEncoding.js
@@ -117,6 +117,23 @@ describe('body encoding', function() {
           });
       });
     });
+    it('should fail with an error when exceeding limit', function(done) {
+      var app = express();
+      app.use(proxy('localhost:8109', {
+        limit: 1,
+      }));
+      // silence jshint warning about unused vars - express error handler *needs* 4 args
+      app.use(function(err, req, res, next) {// jshint ignore:line
+        res.json(err);
+      });
+      request(app)
+        .post('/post')
+        .send({ some: 'json' })
+        .end(function(err, response) {
+          assert(response.body.message === 'request entity too large');
+          done();
+        });
+    });
   });
 
 


### PR DESCRIPTION
The promise that was being returned from the `buildProxyReq` was not handling a rejection if the body parsing failed - for example if the body size exceeded the configured limit. This caused node to throw an unhandled rejection error and crash the request.

By removing the redundant `new Promise` wrapper from around the `Promise.all` call the inner promise will correctly propogate its rejection, and allow it to be caught at https://github.com/villadora/express-http-proxy/blob/11737ce02348fd8077a0ee8db6b14f7a25a0cdb0/index.js#L56