### PR TITLE
Stream proxied responses if no response modifiers are in use

### DIFF
--- a/app/steps/sendProxyRequest.js
+++ b/app/steps/sendProxyRequest.js
@@ -12,6 +12,11 @@ function sendProxyRequest(Container) {
   return new Promise(function(resolve, reject) {
     var protocol = Container.proxy.requestModule;
     var proxyReq = protocol.request(reqOpt, function(rsp) {
+      if (options.stream) {
+        Container.proxy.res = rsp;
+        return resolve(Container);
+      }
+
       var chunks = [];
       rsp.on('data', function(chunk) { chunks.push(chunk); });
       rsp.on('end', function() {

--- a/app/steps/sendUserRes.js
+++ b/app/steps/sendUserRes.js
@@ -2,7 +2,11 @@
 
 function sendUserRes(Container) {
   if (!Container.user.res.headersSent) {
-    Container.user.res.send(Container.proxy.resData);
+    if (Container.options.stream) {
+      Container.proxy.res.pipe(Container.user.res);
+    } else {
+      Container.user.res.send(Container.proxy.resData);
+    }
   }
   return Promise.resolve(Container);
 }

--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -52,6 +52,9 @@ function resolveOptions(options) {
     timeout: options.timeout
   };
 
+  // automatically opt into stream mode if no response modifiers are specified
+  resolved.stream = !resolved.skipToNextHandlerFilter && !resolved.userResDecorator;
+
   debug(resolved);
   return resolved;
 }

--- a/test/streaming.js
+++ b/test/streaming.js
@@ -1,0 +1,58 @@
+var assert = require('assert');
+var express = require('express');
+var http = require('http');
+var startProxyTarget = require('./support/proxyTarget');
+var proxy = require('../');
+
+describe('streams', function() {
+  'use strict';
+  this.timeout(3000);
+
+  var server, targetServer, targetSendChunk, targetEnd;
+
+  beforeEach(function() {
+    var app = express();
+    app.get('/stream', proxy('http://localhost:8309'));
+    server = app.listen(8308);
+
+    var proxyRouteFn = {
+      method: 'get',
+      path: '/stream',
+      fn: function(req, res) {
+        res.write('0');
+        targetSendChunk = function(data) {
+          res.write(data);
+        };
+        targetEnd = function() {
+          res.end();
+        };
+      }
+    };
+    targetServer = startProxyTarget(8309, 1000, [proxyRouteFn]);
+  });
+
+  afterEach(function() {
+    server.close();
+    targetServer.close();
+  });
+
+  it('chunks are received without any buffering', function(done) {
+    var chunks = [];
+    var req = http.request({ hostname: 'localhost', port: 8308, path: '/stream' }, function(res) {
+      res.on('data', function(chunk) {
+        chunks.push(chunk.toString());
+      });
+      res.once('end', function() {
+        assert.deepEqual(chunks, ['0', '1', '2']);
+        done();
+      });
+      targetSendChunk('1');
+      targetSendChunk('2');
+      targetEnd();
+    });
+    req.on('error', function(e) {
+      console.error('problem with request:', e.message);
+    });
+    req.end();
+  });
+});


### PR DESCRIPTION
Needed for my use case where I'm proxying webpack's event-stream.
But also should be a good default for better performance.

The only thing I'm not sure about is error handling cause if this is not quite equivalent it could affect existing apps - otherwise this could be a drop in replacement. All the existing tests pass though, so I was hoping it's solid.

There are several ways to go about introducing this feature:

1. (this PR) **Opt in automatically** - if no response modifiers are in use, simply stream all responses. The potential downsides are that if you just want to modify some header, but not body, that's not possible (but we could open that up in the future if needed). The other downside is potentially different behaviour from before, having said that it seems like streaming is a really good default.
2. **Explicitly opt in using `options.stream` and ignore res modifiers**. Downside is you don't get streaming by default, and another option..
3. **Explicitly opt it using `options.stream` and allow res modifiers**. Here, you still opt into streaming, but `skipToNextHandlerFilter` and `userResDecorator` is still allowed, it's just that proxy.resBody is null and you can only work with headers. the Kind of a bit complicated, maybe?

My thinking was, option 1 is quite seamless. And if we need to go the option 3 route later, it's possible, by introducing `options.stream` override that can be used to both force streaming completely off, or force it on even if modifiers are present but in that case no more handling of body is done.

Anyway, happy to go with any of the options if you agree this is a useful feature.

Fixes #236 