### PR TITLE
Fix crash when gzip indicated and body is empty

### DIFF
--- a/app/steps/decorateUserRes.js
+++ b/app/steps/decorateUserRes.js
@@ -10,7 +10,7 @@ function isResGzipped(res) {
 
 function zipOrUnzip(method) {
   return function(rspData, res) {
-    return (isResGzipped(res)) ? zlib[method](rspData) : rspData;
+    return (isResGzipped(res) && rspData.length) ? zlib[method](rspData) : rspData;
   };
 }
 


### PR DESCRIPTION
Add test, so unzipping is called only when data are present