### PR TITLE
Swap out native http(s) for follow-redirects

### DIFF
--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -1,6 +1,7 @@
 'use strict';
-var http = require('http');
-var https = require('https');
+var redirector = require('follow-redirects');
+var http = redirector.http;
+var https = redirector.https;
 var url = require('url');
 var getRawBody = require('raw-body');
 var isUnset = require('./isUnset');

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "debug": "^3.0.1",
     "es6-promise": "^4.1.1",
+    "follow-redirects": "^1.4.1",
     "raw-body": "^2.3.0"
   },
   "contributors": [


### PR DESCRIPTION
This fixes #91.

Was getting an issue with an API that redirects all calls from their public endpoints. Tests passing.