### PR TITLE
Added async/promise support on the filter() method...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,54 +1,60 @@
-'use strict';
+"use strict";
 
 // * Breaks proxying into a series of discrete steps, many of which can be swapped out by authors.
 // * Uses Promises to support async.
 // * Uses a quasi-Global called Container to tidy up the argument passing between the major work-flow steps.
 
+var ScopeContainer = require("./lib/scopeContainer");
+var assert = require("assert");
+var debug = require("debug")("express-http-proxy");
 
-var ScopeContainer = require('./lib/scopeContainer');
-var assert = require('assert');
-var debug = require('debug')('express-http-proxy');
-
-var buildProxyReq                = require('./app/steps/buildProxyReq');
-var copyProxyResHeadersToUserRes = require('./app/steps/copyProxyResHeadersToUserRes');
-var decorateProxyReqBody         = require('./app/steps/decorateProxyReqBody');
-var decorateProxyReqOpts         = require('./app/steps/decorateProxyReqOpts');
-var decorateUserRes              = require('./app/steps/decorateUserRes');
-var decorateUserResHeaders       = require('./app/steps/decorateUserResHeaders');
-var decorateProxyErrors          = require('./app/steps/decorateProxyErrors');
-var maybeSkipToNextHandler       = require('./app/steps/maybeSkipToNextHandler');
-var prepareProxyReq              = require('./app/steps/prepareProxyReq');
-var resolveProxyHost             = require('./app/steps/resolveProxyHost');
-var resolveProxyReqPath          = require('./app/steps/resolveProxyReqPath');
-var sendProxyRequest             = require('./app/steps/sendProxyRequest');
-var sendUserRes                  = require('./app/steps/sendUserRes');
+var buildProxyReq = require("./app/steps/buildProxyReq");
+var copyProxyResHeadersToUserRes = require("./app/steps/copyProxyResHeadersToUserRes");
+var decorateProxyReqBody = require("./app/steps/decorateProxyReqBody");
+var decorateProxyReqOpts = require("./app/steps/decorateProxyReqOpts");
+var decorateUserRes = require("./app/steps/decorateUserRes");
+var decorateUserResHeaders = require("./app/steps/decorateUserResHeaders");
+var decorateProxyErrors = require("./app/steps/decorateProxyErrors");
+var maybeSkipToNextHandler = require("./app/steps/maybeSkipToNextHandler");
+var prepareProxyReq = require("./app/steps/prepareProxyReq");
+var resolveProxyHost = require("./app/steps/resolveProxyHost");
+var resolveProxyReqPath = require("./app/steps/resolveProxyReqPath");
+var sendProxyRequest = require("./app/steps/sendProxyRequest");
+var sendUserRes = require("./app/steps/sendUserRes");
 
 module.exports = function proxy(host, userOptions) {
-  assert(host, 'Host should not be empty');
+    assert(host, "Host should not be empty");
 
-  return function handleProxy(req, res, next) {
-    debug('[start proxy] ' + req.path);
-    var container = new ScopeContainer(req, res, next, host, userOptions);
+    return function handleProxy(req, res, next) {
+        debug("[start proxy] " + req.path);
+        var container = new ScopeContainer(req, res, next, host, userOptions);
 
-    // Skip proxy if filter is falsey.  Loose equality so filters can return
-    // false, null, undefined, etc.
-    if (!container.options.filter(req, res)) { return next(); }
+        return Promise.resolve(container.options.filter(req, res))
+            .then(function(value) {
+                // Skip proxy if filter is falsey.  Loose equality so filters can return
+                // false, null, undefined, etc.
+                if (!value) {
+                    return next();
+                }
 
-    buildProxyReq(container)
-      .then(resolveProxyHost)
-      .then(decorateProxyReqOpts)
-      .then(resolveProxyReqPath)
-      .then(decorateProxyReqBody)
-      .then(prepareProxyReq)
-      .then(sendProxyRequest)
-      .then(maybeSkipToNextHandler)
-      .then(copyProxyResHeadersToUserRes)
-      .then(decorateUserResHeaders)
-      .then(decorateUserRes)
-      .then(sendUserRes)
-      .catch(function(err) {
-        decorateProxyErrors(err, res, next);
-      });
-  };
+                buildProxyReq(container)
+                    .then(resolveProxyHost)
+                    .then(decorateProxyReqOpts)
+                    .then(resolveProxyReqPath)
+                    .then(decorateProxyReqBody)
+                    .then(prepareProxyReq)
+                    .then(sendProxyRequest)
+                    .then(maybeSkipToNextHandler)
+                    .then(copyProxyResHeadersToUserRes)
+                    .then(decorateUserResHeaders)
+                    .then(decorateUserRes)
+                    .then(sendUserRes)
+                    .catch(function(err) {
+                        decorateProxyErrors(err, res, next);
+                    });
+            })
+            .catch(function(err) {
+                decorateProxyErrors(err, res, next);
+            });
+    };
 };
-


### PR DESCRIPTION
The most important (and only) function which didn't have it. Since this determines whether or not to proxy the request, it's pretty important. We had all our features done in our custom proxy project, but then found out that filter() didn't support async - so a lot of things wouldn't work, like try calling a redis function to get the value, then return true or false depending on that value. Since the filter function didn't support async or promises, then there was no way to wait for redis to complete its callback and get the value before retuning  from the filter function. So I added promise support to the filter() function, and now everything works great! All the tests still passed too. :-)

Sorry for the text reformatting my prettier plug-in did automatically. The only thing that really changed was your original line #35 which corresponds to my line #'s 32 - 38. And I added a new catch handler around the "return Promise.resolve()" handler block.

Anyway, I hope you like the change and other people get good use out of it too.