### PR TITLE
Support proxying behind corporate proxies

### DIFF
--- a/app/steps/resolveProxyHost.js
+++ b/app/steps/resolveProxyHost.js
@@ -4,8 +4,8 @@ var requestOptions = require('../../lib/requestOptions');
 function resolveProxyHost(container) {
   var parsedHost;
 
-  if (container.options.memoizeHost && container.options.memoizedHost) {
-    parsedHost = container.options.memoizedHost;
+  if (container.options.agent) {
+    parsedHost = container.options.agent;
   } else {
     parsedHost = requestOptions.parseHost(container);
   }

--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -56,6 +56,7 @@ function resolveOptions(options) {
     parseReqBody: isUnset(options.parseReqBody) ? true : options.parseReqBody,
     preserveHostHdr: options.preserveHostHdr,
     memoizeHost: isUnset(options.memoizeHost) ? true : options.memoizeHost,
+    agent: options.agent,
     reqBodyEncoding: resolveBodyEncoding(options.reqBodyEncoding),
     skipToNextHandlerFilter: options.skipToNextHandlerFilter,
     headers: options.headers,


### PR DESCRIPTION
The lack of this feature is making it impossible to carry out development behind a corporate proxy.  Prior to version 1.0.0, the solution to this problem was assigning the `http-proxy-agent` object to `req.agent` (#56 ).  

This is not allowed in 1.0.0. 

[This](https://github.com/villadora/express-http-proxy/blob/80057efa8233a7d7ad90d9b1fb61e5a4b46ebc40/app/steps/resolveProxyHost.js#L8) line seems to provision a custom module, but there's no way I can configure that option.  
Are you missing a line [here](https://github.com/villadora/express-http-proxy/blob/80057efa8233a7d7ad90d9b1fb61e5a4b46ebc40/lib/resolveOptions.js#L40)?

@monkpow 