### PR TITLE
check body length instead of 304 code to determine there is no body

### DIFF
--- a/app/steps/decorateUserRes.js
+++ b/app/steps/decorateUserRes.js
@@ -45,8 +45,8 @@ function decorateProxyResBody(container) {
   var req = container.user.req;
   var res = container.user.res;
 
-  if (res.statusCode === 304) {
-    debug('Skipping userResDecorator on response 304');
+  if (proxyResData.length === 0) {
+    debug('Skipping userResDecorator on response with empty proxyResData');
     return Promise.resolve(container);
   }
 

--- a/test/status.js
+++ b/test/status.js
@@ -21,7 +21,7 @@ describe('proxies status code', function () {
     server.close();
   });
 
-  [304, 404, 200, 401, 500].forEach(function (status) {
+  [301, 302, 304, 404, 200, 401, 500].forEach(function (status) {
     it('on ' + status, function (done) {
       request(proxyServer)
         .get('/status/' + status)


### PR DESCRIPTION
there are many scenarios where a response should have no body (302 is what I've encountered, but there are [more](https://stackoverflow.com/a/8628757/11813)).
current behavior is to check for 304 status, I suggest checking the body's length is simpler, covers more real life scenarios (like 200 with no body, it happens some times).