### PR TITLE
[#391] Proper debugging of objects

### DIFF
--- a/app/steps/decorateProxyReqOpts.js
+++ b/app/steps/decorateProxyReqOpts.js
@@ -14,7 +14,7 @@ function decorateProxyReqOpt(container) {
     .then(function (processedReqOpts) {
       delete processedReqOpts.params;
       container.proxy.reqBuilder = processedReqOpts;
-      debug('Request options (after processing):', JSON.stringify(processedReqOpts));
+      debug('Request options (after processing): %o', processedReqOpts);
       return Promise.resolve(container);
     });
 }


### PR DESCRIPTION
When debugging is disabled, calling `debug('Whatever', JSON.stringify(data))` will cause the data to be stringified, even if debugging is disabled. The proper usage of the `debug` package requires to use `%o` or `%O` to pretty-print objects.