### PR TITLE
fix broken test suite from #393

### DIFF
--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -35,7 +35,7 @@ function resolveOptions(options) {
 
   if (options.intercept) {
     console.warn(
-      'DEPRECATED: intercept. Use decorateUseRes instead.' +
+      'DEPRECATED: intercept. Use userResDecorator instead.' +
       ' Please see README for more information.'
     );
   }

--- a/test/middlewareCompatibility.js
+++ b/test/middlewareCompatibility.js
@@ -47,7 +47,7 @@ describe('middleware compatibility', function () {
     });
 
     app.use(proxy('localhost:12346', {
-      decorateUseRes: function (rsp, data, req) {
+      userResDecorator: function (rsp, data, req) {
         assert(req.body);
         assert.equal(req.body.foo, 1);
         assert.equal(req.body.mypost, 'hello');

--- a/test/middlewareCompatibility.js
+++ b/test/middlewareCompatibility.js
@@ -47,7 +47,7 @@ describe('middleware compatibility', function () {
     });
 
     app.use(proxy('localhost:12346', {
-      intercept: function (rsp, data, req) {
+      decorateUseRes: function (rsp, data, req) {
         assert(req.body);
         assert.equal(req.body.foo, 1);
         assert.equal(req.body.mypost, 'hello');

--- a/test/traceDebugging.js
+++ b/test/traceDebugging.js
@@ -7,7 +7,7 @@ var proxy = require('../');
 var proxyTarget = require('../test/support/proxyTarget');
 
 /*  This test is specifically written because of critical errors thrown while debug logging. */
-describe.only('trace debugging does not cause the application to fail', function () {
+describe('trace debugging does not cause the application to fail', function () {
   var proxyServer;
 
   beforeEach(function () { debug.enable('express-http-proxy'); proxyServer = proxyTarget(3000); });

--- a/test/verbs.js
+++ b/test/verbs.js
@@ -24,7 +24,7 @@ describe('http verbs', function () {
       .end(function (err, res) {
         if (err) { return done(err); }
         assert(/node-superagent/.test(res.body.headers['User-Agent']));
-        assert.equal(res.body.url, 'http://httpbin.org/get');
+        assert.equal(res.body.url, 'https://httpbin.org/get');
         done(err);
       });
   });


### PR DESCRIPTION
#393 made it so that only one test that is ever run. If you check the last several travis logs since that PR you will see they never ran any of the other tests.
https://travis-ci.org/villadora/express-http-proxy/jobs/455092315

This PR fixes this

couple notes, in addition to removing the `.only` from the `describe` which allows the rest of the test suite to run, I discovered that http://httpbin.org/get changed the URL that is returned to have `https` so there was a test that was previously being skipped that was failing so I updated that.
I also noticed that the tests threw a deprecation notice since they were using `intercept` instead of `userResDecorator`. I changed the invocation and updated the deprecation notice so that it returns the prints the correct function name.