### PR TITLE
make the user request and response available in skipToNextHandlerFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Allows you to inspect the proxy response, and decide if you want to continue pro
 
 ```js
 app.use('/proxy', proxy('www.google.com', {
-  skipToNextHandlerFilter: function(proxyRes) {
+  skipToNextHandlerFilter: function(proxyRes, userReq, userRes) {
     return proxyRes.statusCode === 404;
   }
 }));

--- a/app/steps/maybeSkipToNextHandler.js
+++ b/app/steps/maybeSkipToNextHandler.js
@@ -1,14 +1,17 @@
 'use strict';
 
-function defaultSkipFilter(/* res */) {
+function defaultSkipFilter(/* proxyRes, userReq, userRes */) {
   return false;
 }
 
 function maybeSkipToNextHandler(container) {
   var resolverFn = container.options.skipToNextHandlerFilter || defaultSkipFilter;
+  var proxyRes = container.proxy.res;
+  var userReq = container.user.req;
+  var userRes = container.user.res;
 
   return Promise
-    .resolve(resolverFn(container.proxy.res))
+    .resolve(resolverFn(proxyRes, userReq, userRes))
     .then(function (shouldSkipToNext) {
       if (shouldSkipToNext) {
         container.user.res.expressHttpProxy = container.proxy;


### PR DESCRIPTION
update the api of `skipToNextHandlerFilter` to be `function(proxyRes, userReq, userRes)  {}`

I have a use case where I need to skip the proxy but not based on the response of the proxy.

This change is backwards compatible with the existing api