### PR TITLE
Swappable HTTP and HTTPS modules

### DIFF
--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -42,10 +42,13 @@ function parseHost(Container) {
 
   var ishttps = options.https || parsed.protocol === 'https:';
 
+  var httpModule = options.httpModule || http;
+  var httpsModule = options.httpsModule || https;
+
   return {
     host: parsed.hostname,
     port: parsed.port || (ishttps ? 443 : 80),
-    module: ishttps ? https : http,
+    module: ishttps ? httpsModule : httpModule
   };
 }
 

--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -61,6 +61,8 @@ function resolveOptions(options) {
     headers: options.headers,
     preserveReqSession: options.preserveReqSession,
     https: options.https,
+    httpModule: options.httpModule,
+    httspModule: options.httpsModule,
     port: options.port,
     reqAsBuffer: options.reqAsBuffer,
     timeout: options.timeout


### PR DESCRIPTION
Hi, I needed support for swapping out the HTTP(s) modules (e.g. to use with AWS X-Ray) so I added those two as options. This is related to other PRs I've seen here where people wanted to use `follow-redirects` and I figured a more universal solution would solve this as well.

If you're interested in this I can add some tests and docs