### PR TITLE
Add more test expectations for body, query and headers using nock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -339,9 +339,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -354,9 +354,9 @@
       "dev": true
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "concat-map": {
@@ -450,6 +450,12 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -887,13 +893,13 @@
       }
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
+      "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -1156,6 +1162,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1333,6 +1345,34 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
+    "nock": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1459,6 +1499,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
     },
     "proxy-addr": {
@@ -1760,9 +1806,9 @@
       }
     },
     "supertest": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.3.0.tgz",
-      "integrity": "sha512-dMQSzYdaZRSANH5LL8kX3UpgK9G1LRh/jnggs/TI0W2Sz7rkMx9Y48uia3K9NgcaWEV28tYkBnXE4tiFC77ygQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.4.2.tgz",
+      "integrity": "sha512-WZWbwceHUo2P36RoEIdXvmqfs47idNNZjCuJOqDz6rvtkk8ym56aU5oglORCpPeXGxT7l9rkJ41+O1lffQXYSA==",
       "dev": true,
       "requires": {
         "methods": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "eslint": "^4.19.1",
     "express": "^4.15.4",
     "mocha": "^5.2.0",
-    "supertest": "^3.0.0"
+    "nock": "^10.0.6",
+    "supertest": "^3.4.2"
   },
   "dependencies": {
     "debug": "^3.0.1",

--- a/test/getBody.js
+++ b/test/getBody.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var bodyParser = require('body-parser');
 var express = require('express');
 var nock = require('nock');
 var request = require('supertest');
@@ -20,6 +21,7 @@ describe('when proxy request is a GET', function () {
 
   beforeEach(function () {
     localServer = createLocalApplicationServer();
+    localServer.use(bodyParser.json());
   });
 
   afterEach(function () {
@@ -58,7 +60,7 @@ describe('when proxy request is a GET', function () {
 
     it('should deliver the get body when ' + test.name, function (done) {
       var nockedPostWithEncoding = nock('http://127.0.0.1:12345')
-        .get('/', { name: 'tobi' })
+        .get('/', test.encoding.includes('json') ? { name: 'tobi' } : '')
         .matchHeader('Content-Type', test.encoding)
         .reply(200, {
           name: 'tobi'
@@ -82,7 +84,7 @@ describe('when proxy request is a GET', function () {
 
   it('should deliver empty string get body', function (done) {
     var nockedPostWithoutBody = nock('http://127.0.0.1:12345')
-      .get('/', '')
+      .get('/', {})
       .matchHeader('Content-Type', 'application/json')
       .reply(200, {
         name: 'get with string body'
@@ -122,6 +124,33 @@ describe('when proxy request is a GET', function () {
       .expect(function (res) {
         assert(res.body.name === 'get with object body');
         nockedPostWithoutBody.done();
+      })
+      .end(done);
+  });
+
+  it('should support parseReqBody', function (done) {
+    var nockedPostWithBody = nock('http://127.0.0.1:12345')
+      .get('/', '')
+      .matchHeader('Content-Type', 'application/json')
+      .reply(200, {
+        name: 'get with parseReqBody false'
+      });
+
+    localServer.use('/proxy', proxy('http://127.0.0.1:12345', {
+      parseReqBody: false,
+    }));
+    localServer.use(function (req, res) { res.sendStatus(200); });
+    localServer.use(function (err, req, res, next) { throw new Error(err, req, res, next); });
+
+    request(localServer)
+      .get('/proxy')
+      .send({
+        name: 'tobi'
+      })
+      .set('Content-Type', 'application/json')
+      .expect(function (res) {
+        assert(res.body.name === 'get with parseReqBody false');
+        nockedPostWithBody.done();
       })
       .end(done);
   });

--- a/test/getBody.js
+++ b/test/getBody.js
@@ -1,0 +1,129 @@
+'use strict';
+
+var assert = require('assert');
+var express = require('express');
+var nock = require('nock');
+var request = require('supertest');
+var proxy = require('../');
+
+
+function createLocalApplicationServer() {
+  var app = express();
+  return app;
+}
+
+describe('when proxy request is a GET', function () {
+
+  this.timeout(10000);
+
+  var localServer;
+
+  beforeEach(function () {
+    localServer = createLocalApplicationServer();
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+  });
+
+  var testCases = [
+    { name: 'form encoded', encoding: 'application/x-www-form-urlencoded' },
+    { name: 'JSON encoded', encoding: 'application/json' }
+  ];
+
+  testCases.forEach(function (test) {
+    it('should deliver the get query when ' + test.name, function (done) {
+      var nockedPostWithEncoding = nock('http://127.0.0.1:12345')
+        .get('/')
+        .query({ name: 'tobi' })
+        .matchHeader('Content-Type', test.encoding)
+        .reply(200, {
+          name: 'tobi'
+        });
+
+      localServer.use('/proxy', proxy('http://127.0.0.1:12345'));
+      localServer.use(function (req, res) { res.sendStatus(200); });
+      localServer.use(function (err, req, res, next) { throw new Error(err, req, res, next); });
+
+      request(localServer)
+        .get('/proxy')
+        .query({ name: 'tobi' })
+        .set('Content-Type', test.encoding)
+        .expect(function (res) {
+          assert(res.body.name === 'tobi');
+          nockedPostWithEncoding.done();
+        })
+        .end(done);
+    });
+
+    it('should deliver the get body when ' + test.name, function (done) {
+      var nockedPostWithEncoding = nock('http://127.0.0.1:12345')
+        .get('/', { name: 'tobi' })
+        .matchHeader('Content-Type', test.encoding)
+        .reply(200, {
+          name: 'tobi'
+        });
+
+      localServer.use('/proxy', proxy('http://127.0.0.1:12345'));
+      localServer.use(function (req, res) { res.sendStatus(200); });
+      localServer.use(function (err, req, res, next) { throw new Error(err, req, res, next); });
+
+      request(localServer)
+        .get('/proxy')
+        .send({ name: 'tobi' })
+        .set('Content-Type', test.encoding)
+        .expect(function (res) {
+          assert(res.body.name === 'tobi');
+          nockedPostWithEncoding.done();
+        })
+        .end(done);
+    });
+  });
+
+  it('should deliver empty string get body', function (done) {
+    var nockedPostWithoutBody = nock('http://127.0.0.1:12345')
+      .get('/', '')
+      .matchHeader('Content-Type', 'application/json')
+      .reply(200, {
+        name: 'get with string body'
+      });
+
+    localServer.use('/proxy', proxy('http://127.0.0.1:12345'));
+    localServer.use(function (req, res) { res.sendStatus(200); });
+    localServer.use(function (err, req, res, next) { throw new Error(err, req, res, next); });
+
+    request(localServer)
+      .get('/proxy')
+      .send()
+      .set('Content-Type', 'application/json')
+      .expect(function (res) {
+        assert(res.body.name === 'get with string body');
+        nockedPostWithoutBody.done();
+      })
+      .end(done);
+  });
+
+  it('should deliver empty object get body', function (done) {
+    var nockedPostWithoutBody = nock('http://127.0.0.1:12345')
+      .get('/', {})
+      .matchHeader('Content-Type', 'application/json')
+      .reply(200, {
+        name: 'get with object body'
+      });
+
+    localServer.use('/proxy', proxy('http://127.0.0.1:12345'));
+    localServer.use(function (req, res) { res.sendStatus(200); });
+    localServer.use(function (err, req, res, next) { throw new Error(err, req, res, next); });
+
+    request(localServer)
+      .get('/proxy')
+      .send({})
+      .set('Content-Type', 'application/json')
+      .expect(function (res) {
+        assert(res.body.name === 'get with object body');
+        nockedPostWithoutBody.done();
+      })
+      .end(done);
+  });
+
+});


### PR DESCRIPTION
We are debugging a case where our get body is being converted into an `{}` object before being sent to the upstream proxied service. 

To debug this, I added some more test expectations for the body, query and headers using nock https://www.npmjs.com/package/nock#request-headers-matching if you're interested, I made it into a pr. 

With this test i was able to show that its not express-http-proxy thats introducing the body. 