### PR TITLE
Async getHost support, Node 12 deprecation fix

### DIFF
--- a/app/steps/decorateUserResHeaders.js
+++ b/app/steps/decorateUserResHeaders.js
@@ -3,7 +3,7 @@
 
 function decorateUserResHeaders(container) {
   var resolverFn = container.options.userResHeaderDecorator;
-  var headers = container.user.res._headers;
+  var headers = container.user.res.getHeaders();
 
   if (!resolverFn) {
     return Promise.resolve(container);

--- a/app/steps/decorateUserResHeaders.js
+++ b/app/steps/decorateUserResHeaders.js
@@ -3,7 +3,7 @@
 
 function decorateUserResHeaders(container) {
   var resolverFn = container.options.userResHeaderDecorator;
-  var headers = container.user.res.getHeaders();
+  var headers = container.user.res.getHeaders ? container.user.res.getHeaders() : container.user.res._headers;
 
   if (!resolverFn) {
     return Promise.resolve(container);

--- a/app/steps/resolveProxyHost.js
+++ b/app/steps/resolveProxyHost.js
@@ -10,10 +10,12 @@ function resolveProxyHost(container) {
     parsedHost = requestOptions.parseHost(container);
   }
 
-  container.proxy.reqBuilder.host = parsedHost.host;
-  container.proxy.reqBuilder.port = container.options.port || parsedHost.port;
-  container.proxy.requestModule = parsedHost.module;
-  return Promise.resolve(container);
+  return Promise.resolve(parsedHost).then((parsedHost) => {
+    container.proxy.reqBuilder.host = parsedHost.host;
+    container.proxy.reqBuilder.port = container.options.port || parsedHost.port;
+    container.proxy.requestModule = parsedHost.module;
+    return Promise.resolve(container);
+  });
 }
 
 module.exports = resolveProxyHost;

--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -30,23 +30,25 @@ function parseHost(Container) {
     return new Error('Empty host parameter');
   }
 
-  if (!/http(s)?:\/\//.test(host)) {
-    host = 'http://' + host;
-  }
+  return Promise.resolve(host).then((host) => {
+    if (!/http(s)?:\/\//.test(host)) {
+      host = 'http://' + host;
+    }
 
-  var parsed = url.parse(host);
+    var parsed = url.parse(host);
 
-  if (!parsed.hostname) {
-    return new Error('Unable to parse hostname, possibly missing protocol://?');
-  }
+    if (!parsed.hostname) {
+      return new Error('Unable to parse hostname, possibly missing protocol://?');
+    }
 
-  var ishttps = options.https || parsed.protocol === 'https:';
+    var ishttps = options.https || parsed.protocol === 'https:';
 
-  return {
-    host: parsed.hostname,
-    port: parsed.port || (ishttps ? 443 : 80),
-    module: ishttps ? https : http,
-  };
+    return {
+      host: parsed.hostname,
+      port: parsed.port || (ishttps ? 443 : 80),
+      module: ishttps ? https : http,
+    };
+  });
 }
 
 function reqHeaders(req, options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,9 +1135,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1167,9 +1167,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lru-cache": {

--- a/test/userResDecorator.js
+++ b/test/userResDecorator.js
@@ -160,7 +160,7 @@ describe('userResDecorator', function () {
 
     proxyApp.use(proxy(redirectingServerOrigin, {
       userResDecorator: function (rsp, data, req, res) {
-        var proxyReturnedLocation = res._headers.location;
+        var proxyReturnedLocation = res.getHeaders ? res.getHeaders().location : res._headers.location;
         res.location(proxyReturnedLocation.replace(redirectingServerPort, preferredPort));
         return data;
       }


### PR DESCRIPTION
Asynchronous "getHost" implementation:
Issue https://github.com/villadora/express-http-proxy/issues/284

OutgoingMessage.prototype._headers is deprecated in Node.js 12:
Issue https://github.com/villadora/express-http-proxy/issues/413