### PR TITLE
OutgoingMessage.prototype._headers is deprecated in Node.js 12. make …

### DIFF
--- a/app/steps/decorateUserResHeaders.js
+++ b/app/steps/decorateUserResHeaders.js
@@ -3,7 +3,7 @@
 
 function decorateUserResHeaders(container) {
   var resolverFn = container.options.userResHeaderDecorator;
-  var headers = container.user.res._headers;
+  var headers = container.user.res.getHeaders ? container.user.res.getHeaders() : container.user.res._headers;
 
   if (!resolverFn) {
     return Promise.resolve(container);

--- a/test/userResDecorator.js
+++ b/test/userResDecorator.js
@@ -160,7 +160,7 @@ describe('userResDecorator', function () {
 
     proxyApp.use(proxy(redirectingServerOrigin, {
       userResDecorator: function (rsp, data, req, res) {
-        var proxyReturnedLocation = res._headers.location;
+        var proxyReturnedLocation = res.getHeaders ? res.getHeaders().location : res._headers.location;
         res.location(proxyReturnedLocation.replace(redirectingServerPort, preferredPort));
         return data;
       }


### PR DESCRIPTION
…sure res.getHeaders() exists for Node 6

@ConnorWhite I plucked these commits from your branch and am planning to merge them.    Let me know if you have any objections. 