### PR TITLE
add optional next() after proxy processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,23 @@ Conversely, When ```memoizeHost:true```,  the coinToss would occur on the first
 request, and all additional requests would return the value resolved on the
 first request.
 
+#### optionalNext
+
+Defaults to ```false```.
+
+When ```true```, the ```next``` middleware function will be executed on the final step returning control to the host application.
+
+```
+const options = {
+    optionalNext: true
+}
+
+app.use(middleware.onBefore);
+app.use('/api', proxy('http://yahoo.com', options));
+app.use(middleware.onAfter);
+```
+
+In the above example, ```middleware.onAfter``` will be called if ```optionalNext``` is ```true```.
 
 ### userResHeaderDecorator
 

--- a/app/steps/optionalNext.js
+++ b/app/steps/optionalNext.js
@@ -2,7 +2,7 @@
 'use strict';
 
 function optionalNext(container, next) {
-    if (container.params.userOptions.optionalNext) {
+    if (container.params && container.params.userOptions && container.params.userOptions.optionalNext) {
         next();
         return Promise.resolve();
     }

--- a/app/steps/optionalNext.js
+++ b/app/steps/optionalNext.js
@@ -1,0 +1,12 @@
+
+'use strict';
+
+function optionalNext(container, next) {
+    if (container.params.userOptions.optionalNext) {
+        next();
+        return Promise.resolve();
+    }
+    else return Promise.resolve();
+}
+
+module.exports = optionalNext;

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var resolveProxyHost             = require('./app/steps/resolveProxyHost');
 var resolveProxyReqPath          = require('./app/steps/resolveProxyReqPath');
 var sendProxyRequest             = require('./app/steps/sendProxyRequest');
 var sendUserRes                  = require('./app/steps/sendUserRes');
+var optionalNext                 = require('./app/steps/optionalNext.js');
 
 module.exports = function proxy(host, userOptions) {
   assert(host, 'Host should not be empty');
@@ -43,6 +44,7 @@ module.exports = function proxy(host, userOptions) {
       .then(decorateUserResHeaders)
       .then(decorateUserRes)
       .then(sendUserRes)
+      .then((container) => optionalNext(container, next))
       .catch(function (err) {
         // I sometimes reject without an error to shortcircuit the remaining
         // steps and return control to the host application.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-http-proxy",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-http-proxy",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "http proxy middleware for express",
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
not sure if you may find it useful, but I like to have a 'final' middleware function at the end of my requests (similar to .net's onAfterExecuting). I added and tested the 