### PR TITLE
Regenerate etag header if response body may have changed

### DIFF
--- a/app/steps/decorateUserRes.js
+++ b/app/steps/decorateUserRes.js
@@ -38,6 +38,11 @@ function verifyBuffer(rspd, reject) {
 function updateHeaders(res, rspdBefore, rspdAfter, reject) {
   if (!res.headersSent) {
       res.set('content-length', rspdAfter.length);
+      /**
+       * Force Express to regenerate the etag as body may have changed.
+       * Prevents 304 Not Modified when rspdBefore is unchanged but rspdAfter has.
+       */
+      res.set('etag', '');
   } else if (rspdAfter.length !== rspdBefore.length) {
       var error = '"Content-Length" is already sent,' +
           'the length of response data can not be changed';

--- a/test/userResDecorator.js
+++ b/test/userResDecorator.js
@@ -98,6 +98,30 @@ describe('userResDecorator', function () {
       });
   });
 
+  it('should remove downstream etag when body has changed', function (done) {
+    var app = express();
+
+    app.use(proxy('httpbin.org', {
+      userResDecorator: function (proxyRes, proxyResData) {
+        // Confirm httpbin.org returned the expected etag
+        assert.equal(proxyRes.headers.etag, 'fakeEtag');
+
+        return JSON.stringify({ origin: '127.0.0.1' });
+      }
+    }));
+
+    request(app)
+        .get('/etag/fakeEtag')
+        .set('if-none-matches', 'fakeEtag')
+        .end(function (err, res) {
+          if (err) { return done(err); }
+
+          // Expected SHA1 of decorated body { origin: '127.0.0.1' }
+          assert.equal(res.header.etag, 'W/"16-uXy9BGroO9vX02Z2Pu7mYgig2Qo"');
+          done();
+        });
+  });
+
 
   it('can modify the response headers, [deviant case, supported by pass-by-reference atm]', function (done) {
     var app = express();


### PR DESCRIPTION
### Change
Clear the etag header to force Express to regenerate the etag as body may have changed. This prevents 304 Not Modified when downstream response is unchanged but userResDecorator has.

### Background
We found an issue in our live deployment where the client was using stale cached responses. The issue was the downstream web server responding with an `etag` header based on it's response body which was unchanged.

`express-http-proxy` proxies this `etag` header back to the client even when `userResDecorator` may have changed the response. In our scenario the amendment to the response is itself dynamic.

The fix was straightforward but I thought this gotcha could be affecting many people without their knowledge.

### Workaround without changing `express-http-proxy`

```typescript
const ResetEtagHeader = (headers: IncomingHttpHeaders): OutgoingHttpHeaders => {
  // Clear the etag header so NWA Express will regenerate it
  headers.etag = '';
  return headers;
};

proxy(serverURL, {
      userResDecorator: DynamicDecoratorBlah,
      userResHeaderDecorator: ResetEtagHeader,
});
```