### PR TITLE
Supporting proxy after request body has been read

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,25 @@ app.use('/', proxy(selectProxyHost));
 
 If you use 'https://www.npmjs.com/package/body-parser' you should declare it AFTER the proxy configuration, otherwise  original 'POST' body could be modified and not proxied correctly.
 
-```
-
-app.use('/proxy', 'http://foo.bar.com')
+```js
+app.use('/proxy', proxy('http://foo.bar.com'))
 
 // Declare use of body-parser AFTER the use of proxy
 app.use(bodyParser.foo(bar))
 app.use('/api', ...)
+```
+
+If this cannot be avoided and you MUST proxy after `body-parser` has been registered, set `parseReqBody` to `false` and explicitly specify the body you wish to send in `proxyReqBodyDecorator`.
+
+```js
+app.use(bodyParser.foo(bar))
+
+app.use('/proxy', proxy('http://foo.bar.com', {
+  parseReqBody: false,
+  proxyReqBodyDecorator: function () {
+
+  },
+}))
 ```
 
 ### Options

--- a/app/steps/sendProxyRequest.js
+++ b/app/steps/sendProxyRequest.js
@@ -62,6 +62,9 @@ function sendProxyRequest(Container) {
         proxyReq.write(body);
       }
       proxyReq.end();
+    } else if (bodyContent) {
+      proxyReq.write(bodyContent);
+      proxyReq.end();
     } else {
     // Pipe will call end when it has completely read from the request.
       req.pipe(proxyReq);

--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -90,6 +90,11 @@ function bodyContent(req, res, options) {
   function maybeParseBody(req, limit) {
     if (req.body) {
       return Promise.resolve(req.body);
+    } else if (!req.readable) {
+      return Promise.reject(
+        'Tried to parse body after request body has already been read.' +
+        ' Try setting parseReqBody to false and manually specify the body you want to send in decorateProxyReqBody.'
+      );
     } else {
       // Returns a promise if no callback specified and global Promise exists.
 

--- a/test/getBody.js
+++ b/test/getBody.js
@@ -155,4 +155,30 @@ describe('when proxy request is a GET', function () {
       .end(done);
   });
 
+  it('should use proxyReqBodyDecorator with parseReqBody=false', function (done) {
+    var scope = nock('http://127.0.0.1:12345')
+      .get('/', {})
+      .matchHeader('Content-Type', 'application/json')
+      .reply(200, {
+        name: 'proxyReqBodyDecorator + parseReqBody=false works'
+      });
+
+    var payload = {};
+
+    localServer.use('/proxy', proxy('http://127.0.0.1:12345', {
+      parseReqBody: false,
+      proxyReqBodyDecorator: () => JSON.stringify(payload),
+    }));
+
+    request(localServer)
+      .get('/proxy')
+      .send(payload)
+      .set('Content-Type', 'application/json')
+      .expect(function (res) {
+        assert(res.body.name === 'proxyReqBodyDecorator + parseReqBody=false works');
+        scope.done();
+      })
+      .end(done);
+  });
+
 });

--- a/test/getBody.js
+++ b/test/getBody.js
@@ -181,4 +181,70 @@ describe('when proxy request is a GET', function () {
       .end(done);
   });
 
+  describe('when body-parser.json() is using strict=false', function () {
+    beforeEach(function () {
+      localServer = createLocalApplicationServer();
+      localServer.use(bodyParser.json({ strict: false }));
+    });
+
+    var testCases = [
+      { value: false },
+      { value: null },
+      { value: '' },
+    ];
+
+    testCases.forEach(function (test) {
+      var valueString = JSON.stringify(test.value);
+
+      it('errors when body is ' + valueString, function (done) {
+        localServer.use('/proxy', proxy('http://127.0.0.1:12345'));
+        localServer.use(function (err, req, res, next) { res.send(err); next(); });
+
+        request(localServer)
+          .get('/proxy')
+          .send(valueString)
+          .set('Content-Type', 'application/json')
+          .expect(function (res) {
+            assert(
+              res.text === (
+                'Tried to parse body after request body has already been read.' +
+                ' Try setting parseReqBody to false and manually specify the body' +
+                ' you want to send in decorateProxyReqBody.'
+              )
+            );
+          })
+          .end(done);
+      });
+
+      it(
+        'succeeds when parseReqBody=false and proxyReqBodyDecorator explicitly returns ' + valueString,
+        function (done) {
+          var scope = nock('http://127.0.0.1:12345')
+            .get('/', valueString)
+            .matchHeader('Content-Type', 'application/json')
+            .reply(200, valueString, {
+              'Content-Type': 'application/json',
+            });
+
+          localServer.use('/proxy', proxy('http://127.0.0.1:12345', {
+            parseReqBody: false,
+            proxyReqBodyDecorator: function () {
+              return valueString;
+            },
+          }));
+
+          request(localServer)
+            .get('/proxy')
+            .send(valueString)
+            .set('Content-Type', 'application/json')
+            .expect(function (res) {
+              assert(res.body === test.value);
+              scope.done();
+            })
+            .end(done);
+        }
+      );
+    });
+  });
+
 });

--- a/test/postBody.js
+++ b/test/postBody.js
@@ -128,4 +128,30 @@ describe('when proxy request is a POST', function () {
       .end(done);
   });
 
+  it('should use proxyReqBodyDecorator with parseReqBody=false', function (done) {
+    var scope = nock('http://127.0.0.1:12345')
+      .post('/', {})
+      .matchHeader('Content-Type', 'application/json')
+      .reply(200, {
+        name: 'proxyReqBodyDecorator + parseReqBody=false works'
+      });
+
+    var payload = {};
+
+    localServer.use('/proxy', proxy('http://127.0.0.1:12345', {
+      parseReqBody: false,
+      proxyReqBodyDecorator: () => JSON.stringify(payload),
+    }));
+
+    request(localServer)
+      .post('/proxy')
+      .send(payload)
+      .set('Content-Type', 'application/json')
+      .expect(function (res) {
+        assert(res.body.name === 'proxyReqBodyDecorator + parseReqBody=false works');
+        scope.done();
+      })
+      .end(done);
+  });
+
 });


### PR DESCRIPTION
Our exact use-case is a bit special:
1. We have a NestJS application, and we still want to use our NestJS guards before proxying
2. Our endpoint needs to set `{ strict: false }` for the JSON body parser, because our proxied endpoint can take in non-objects as input
3. We don't want to parse the incoming request at all. The exact use case we're thinking of is JSON data with big ints that would get rounded if it went through standard `body-parser` functions

So to implement this, we extracted out the raw body before `body-parser` can touch it, then for our proxy, we did
```
proxy('...', {
  proxyReqBodyDecorator: () => rawBody,
})
```
to completely ignore the body that was parsed by `body-parser`/`express-http-proxy` and manually set the body back to the raw body we got.

But in our testing, we noticed that sending values that would be parsed as falsy JSON values, like `'false'` or `'""'`, our tests would hang. Basically, it would get to 

https://github.com/villadora/express-http-proxy/blob/2aec18894bfe4d06fc61d959cf718c9e1496226e/lib/requestOptions.js#L91-L100

and `req.body` would be falsy, so it would try to read the request body stream. But the stream had already been read, meaning that `getRawBody` will never return.

Just setting `parseReqBody` to `false` didn't help either because it would skip the entire section that sends the result of `proxyReqBodyDecorator` and try to pipe the original request's body to the proxy request, which wouldn't pipe anything because the request body had already been read.

https://github.com/villadora/express-http-proxy/blob/2aec18894bfe4d06fc61d959cf718c9e1496226e/app/steps/sendProxyRequest.js#L40-L68

To fix the latter point, I'm checking `bodyContent` if `parseReqBody` is `false` and sending that if it's populated. In [normal operation](https://github.com/villadora/express-http-proxy/blob/master/app/steps/buildProxyReq.js#L12), `bodyContent` is `null`, but with `proxyReqBodyDecorator`, `bodyContent` is populated.

To fix the hanging, I added an explicit check in `requestOptions` that makes sure the request hasn't already been read. This shouldn't happen in normal operation, but it would've saved me a lot of headache if it were there. Another option is to change `if (req.body)` to `if (req.body !== undefined)`, but I figured that would be more change in behavior than this library might want.