### PR TITLE
use getHeaders instead of deprecated _headers prop

### DIFF
--- a/app/steps/decorateUserResHeaders.js
+++ b/app/steps/decorateUserResHeaders.js
@@ -10,7 +10,7 @@ function decorateUserResHeaders(container) {
   }
 
   const clearAllHeaders = (res) => {
-    for (const header in res._headers) {
+    for (const header in res.getHeaders ? res.getHeaders() : res._headers) {
       res.removeHeader(header)
     }
   }


### PR DESCRIPTION
Inspired by https://github.com/villadora/express-http-proxy/pull/430/files